### PR TITLE
Refactoring instantiatie context

### DIFF
--- a/__test-utils__/mocks/contexts.ts
+++ b/__test-utils__/mocks/contexts.ts
@@ -3,12 +3,10 @@
 
 import BN from 'bn.js';
 import { jest } from '@jest/globals';
-import { randomAsHex } from '@polkadot/util-crypto';
 import { LOCAL_NODE } from '../../src/constants';
 import { getMockDb, mockDbUser } from './db';
 import { mockKeyring } from './keyring';
-import { getMockFormField } from './hooks';
-import type { DbState, ApiPromise, InstantiateProps, AbiConstructor } from 'types';
+import type { DbState, ApiPromise, InstantiateProps } from 'types';
 
 export const mockDbState = {
   db: undefined,
@@ -46,47 +44,19 @@ export const mockApiState = {
 
 export function getMockInstantiateState(): InstantiateProps {
   return {
-    accountId: getMockFormField<string | null>(
-      '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
-      true
-    ),
-    argValues: [{ initValue: 'true' }, jest.fn()],
-    codeHash: '0xd0bc2fee1ad35d66436a1ee818859322b24ba8c9ad80a26ef369cdd2666d173d',
-    constructorIndex: getMockFormField(0),
-    deployConstructor: {} as AbiConstructor,
-    endowment: { ...getMockFormField<BN | null | undefined>(new BN(10000).mul(new BN(10e12))) },
-    isLoading: false,
-    isUsingSalt: [false, jest.fn(), jest.fn()],
-    isUsingStoredMetadata: false,
-    metadata: {
-      isError: false,
-      isSupplied: false,
-      isValid: false,
-      message: null,
-      name: '',
-      source: null,
-      value: null,
-      onChange: jest.fn(),
-      onRemove: jest.fn(),
-    },
-    metadataFile: [undefined, jest.fn()],
-    name: getMockFormField('flipper', true),
-    onInstantiate: jest.fn(),
-    onError: jest.fn(),
-    onSuccess: jest.fn(),
-    salt: getMockFormField<string>(randomAsHex(), true),
-    step: [0, jest.fn(), jest.fn(), jest.fn()],
-    weight: {
-      executionTime: 0,
-      isEmpty: false,
-      isValid: true,
-      megaGas: new BN(0),
-      percentage: 0,
-      setIsEmpty: jest.fn(),
-      setMegaGas: jest.fn(),
+    data: {
+      accountId: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+      argValues: { initValue: 'true' },
+      codeHash: '0xd0bc2fee1ad35d66436a1ee818859322b24ba8c9ad80a26ef369cdd2666d173d',
+      constructorIndex: 0,
+      endowment: new BN(10000),
       weight: new BN(0),
+      name: 'flipper',
     },
-    tx: null,
-    txError: null,
+
+    // onInstantiate: jest.fn(),
+    // onError: jest.fn(),
+    // onSuccess: jest.fn(),
+    currentStep: 0,
   };
 }

--- a/__test-utils__/mocks/contexts.ts
+++ b/__test-utils__/mocks/contexts.ts
@@ -42,21 +42,19 @@ export const mockApiState = {
   status: 'READY',
 } as unknown as CanvasState;
 
-export function getMockInstantiateState(): InstantiateProps {
-  return {
-    data: {
-      accountId: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
-      argValues: { initValue: 'true' },
-      codeHash: '0xd0bc2fee1ad35d66436a1ee818859322b24ba8c9ad80a26ef369cdd2666d173d',
-      constructorIndex: 0,
-      endowment: new BN(10000),
-      weight: new BN(0),
-      name: 'flipper',
-    },
+export const mockInstantiateState: InstantiateProps = {
+  data: {
+    accountId: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+    argValues: { initValue: 'true' },
+    codeHash: '0xd0bc2fee1ad35d66436a1ee818859322b24ba8c9ad80a26ef369cdd2666d173d',
+    constructorIndex: 0,
+    endowment: new BN(10000),
+    weight: new BN(0),
+    name: 'flipper',
+  },
 
-    // onInstantiate: jest.fn(),
-    // onError: jest.fn(),
-    // onSuccess: jest.fn(),
-    currentStep: 0,
-  };
-}
+  // onInstantiate: jest.fn(),
+  // onError: jest.fn(),
+  // onSuccess: jest.fn(),
+  currentStep: 1,
+};

--- a/__test-utils__/mocks/contexts.ts
+++ b/__test-utils__/mocks/contexts.ts
@@ -6,7 +6,7 @@ import { jest } from '@jest/globals';
 import { LOCAL_NODE } from '../../src/constants';
 import { getMockDb, mockDbUser } from './db';
 import { mockKeyring } from './keyring';
-import type { DbState, ApiPromise, InstantiateProps } from 'types';
+import type { DbState, ApiPromise, InstantiateProps, ApiState } from 'types';
 
 export const mockDbState = {
   db: undefined,
@@ -40,7 +40,7 @@ export const mockApiState = {
   keyring: mockKeyring,
   keyringStatus: 'READY',
   status: 'READY',
-} as unknown as CanvasState;
+} as unknown as ApiState;
 
 export const mockInstantiateState: InstantiateProps = {
   data: {
@@ -52,9 +52,9 @@ export const mockInstantiateState: InstantiateProps = {
     weight: new BN(0),
     name: 'flipper',
   },
-
-  // onInstantiate: jest.fn(),
-  // onError: jest.fn(),
-  // onSuccess: jest.fn(),
+  onSuccess: jest.fn(),
   currentStep: 1,
+  tx: null,
+  onError: jest.fn(),
+  onInstantiate: jest.fn(),
 };

--- a/__test-utils__/mocks/db.ts
+++ b/__test-utils__/mocks/db.ts
@@ -15,7 +15,13 @@ import {
   publicKeyHex,
 } from 'db';
 
-import type { UserDocument, CodeBundleDocument, ContractDocument, PrivateKey } from 'types';
+import type {
+  UserDocument,
+  CodeBundleDocument,
+  ContractDocument,
+  PrivateKey,
+  AnyJson,
+} from 'types';
 import { MOCK_CONTRACT_DATA } from 'ui/util';
 
 type TestUser = [UserDocument, PrivateKey];
@@ -63,7 +69,7 @@ export function getMockCodeBundles(): CodeBundleDocument[] {
   const genesisHash = randomHash();
 
   MOCK_CONTRACT_DATA.forEach(([name, , tags]) => {
-    const abi = (contractFiles as Record<string, Record<string, unknown>>)[name];
+    const abi = (contractFiles as Record<string, AnyJson>)[name.toLowerCase()];
 
     codeBundles.push({
       blockZeroHash: blockZeroHashes[Math.round(Math.random())],
@@ -90,7 +96,7 @@ export function getMockContracts(codeBundles: CodeBundleDocument[]): ContractDoc
 
   // Original instantiation and 0-2 reinstantiations
   MOCK_CONTRACT_DATA.forEach(([name, , tags], index) => {
-    const abi = (contractFiles as Record<string, Record<string, unknown>>)[name.toLowerCase()];
+    const abi = (contractFiles as Record<string, AnyJson>)[name.toLowerCase()];
 
     contracts.push({
       address: faker.random.alphaNumeric(62),

--- a/__test-utils__/mocks/hooks.ts
+++ b/__test-utils__/mocks/hooks.ts
@@ -4,7 +4,7 @@
 import { jest } from '@jest/globals';
 import type { UseFormField } from 'types';
 
-export function getMockFormField<T>(value: T | undefined, isValid = false): UseFormField<T> {
+export function getMockFormField<T>(value: T, isValid = false): UseFormField<T> {
   return {
     onChange: jest.fn(),
     value,

--- a/__tests__/ui/components/AccountSelect.test.tsx
+++ b/__tests__/ui/components/AccountSelect.test.tsx
@@ -6,13 +6,11 @@ import { jest } from '@jest/globals';
 import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AccountSelect } from 'ui/components/account/AccountSelect';
-import { DropdownProps, OrNull } from 'types';
+import { DropdownProps } from 'types';
 import { mockKeyring, customRender } from 'test-utils';
 import { truncate } from 'ui/util';
 
-function mockProps(
-  overrides: Partial<DropdownProps<OrNull<string>>> = {}
-): DropdownProps<OrNull<string>> {
+function mockProps(overrides: Partial<DropdownProps<string>> = {}): DropdownProps<string> {
   const value = mockKeyring.getAccounts()[0].address;
 
   return {

--- a/__tests__/ui/components/Dropdown.test.tsx
+++ b/__tests__/ui/components/Dropdown.test.tsx
@@ -50,7 +50,7 @@ describe('Dropdown', () => {
 
   test('correctly renders without options', () => {
     const { getByText } = render(
-      <Dropdown onChange={jest.fn() as () => void}>No options found</Dropdown>
+      <Dropdown {...mockProps({ options: undefined })}>No options found</Dropdown>
     );
 
     const dropdown = getByText('No options found');

--- a/__tests__/ui/components/instantiate/Step1.test.tsx
+++ b/__tests__/ui/components/instantiate/Step1.test.tsx
@@ -4,14 +4,14 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { Step1 } from 'ui/components/instantiate/Step1';
-import { InstantiateContext } from 'ui/contexts';
+import { InstantiateContextProvider } from 'ui/contexts';
 import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={{ ...mockInstantiateState }}>
+    <InstantiateContextProvider {...mockInstantiateState}>
       <Step1 />
-    </InstantiateContext.Provider>
+    </InstantiateContextProvider>
   );
 }
 

--- a/__tests__/ui/components/instantiate/Step1.test.tsx
+++ b/__tests__/ui/components/instantiate/Step1.test.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { Step1 } from 'ui/components/instantiate/Step1';
 import { InstantiateContext } from 'ui/contexts';
-import { customRender as customRenderBase, getMockInstantiateState } from 'test-utils';
+import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={getMockInstantiateState()}>
+    <InstantiateContext.Provider value={{ ...mockInstantiateState }}>
       <Step1 />
     </InstantiateContext.Provider>
   );

--- a/__tests__/ui/components/instantiate/Step2.test.tsx
+++ b/__tests__/ui/components/instantiate/Step2.test.tsx
@@ -6,11 +6,11 @@ import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Step2 } from 'ui/components/instantiate/Step2';
 import { InstantiateContext } from 'ui/contexts';
-import { customRender as customRenderBase, getMockInstantiateState } from 'test-utils';
+import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={getMockInstantiateState()}>
+    <InstantiateContext.Provider value={{ ...mockInstantiateState, currentStep: 2 }}>
       <Step2 />
     </InstantiateContext.Provider>
   );

--- a/__tests__/ui/components/instantiate/Step2.test.tsx
+++ b/__tests__/ui/components/instantiate/Step2.test.tsx
@@ -5,14 +5,14 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Step2 } from 'ui/components/instantiate/Step2';
-import { InstantiateContext } from 'ui/contexts';
+import { InstantiateContextProvider } from 'ui/contexts';
 import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={{ ...mockInstantiateState, currentStep: 2 }}>
+    <InstantiateContextProvider {...{ ...mockInstantiateState, currentStep: 2 }}>
       <Step2 />
-    </InstantiateContext.Provider>
+    </InstantiateContextProvider>
   );
 }
 

--- a/__tests__/ui/components/instantiate/Step3.test.tsx
+++ b/__tests__/ui/components/instantiate/Step3.test.tsx
@@ -7,14 +7,14 @@ import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 // import { mockAbiFlipper } from 'test-utils';
 import { Step3 } from 'ui/components/instantiate/Step3';
-import { InstantiateContext } from 'ui/contexts';
+import { InstantiateContextProvider } from 'ui/contexts';
 import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={{ ...mockInstantiateState, currentStep: 3 }}>
+    <InstantiateContextProvider {...{ ...mockInstantiateState, currentStep: 3 }}>
       <Step3 />
-    </InstantiateContext.Provider>
+    </InstantiateContextProvider>
   );
 }
 describe('Instantiate Step 3', () => {

--- a/__tests__/ui/components/instantiate/Step3.test.tsx
+++ b/__tests__/ui/components/instantiate/Step3.test.tsx
@@ -8,11 +8,11 @@ import '@testing-library/jest-dom/extend-expect';
 // import { mockAbiFlipper } from 'test-utils';
 import { Step3 } from 'ui/components/instantiate/Step3';
 import { InstantiateContext } from 'ui/contexts';
-import { customRender as customRenderBase, getMockInstantiateState } from 'test-utils';
+import { customRender as customRenderBase, mockInstantiateState } from 'test-utils';
 
 function customRender() {
   return customRenderBase(
-    <InstantiateContext.Provider value={getMockInstantiateState()}>
+    <InstantiateContext.Provider value={{ ...mockInstantiateState, currentStep: 3 }}>
       <Step3 />
     </InstantiateContext.Provider>
   );

--- a/__tests__/ui/hooks/useAccountId.test.ts
+++ b/__tests__/ui/hooks/useAccountId.test.ts
@@ -45,7 +45,7 @@ describe('useAccountId', () => {
     const [{ result }] = customRenderHook(() => useAccountId());
 
     act(() => {
-      result.current.onChange(null);
+      result.current.onChange('');
     });
 
     expect(extractResult(result)).toMatchObject({
@@ -54,7 +54,7 @@ describe('useAccountId', () => {
       isValid: false,
       isWarning: false,
       message: 'Specified account does not exist',
-      value: null,
+      value: '',
     });
 
     act(() => {

--- a/__tests__/ui/hooks/useDbQuery.test.ts
+++ b/__tests__/ui/hooks/useDbQuery.test.ts
@@ -3,7 +3,7 @@
 
 import { act, RenderResult } from '@testing-library/react-hooks';
 import { jest } from '@jest/globals';
-import type { OrFalsy, OrNull, UseQuery } from 'types';
+import type { OrFalsy, OrNull, DbQuery } from 'types';
 import { useDbQuery } from 'ui/hooks/useDbQuery';
 import { customRenderHook, timeout } from 'test-utils';
 
@@ -42,8 +42,8 @@ function mockQuery(argument: number): () => Promise<OrNull<ReturnType>> {
 const consoleError = console.error;
 
 function extractResult(
-  result: RenderResult<UseQuery<ReturnType>>
-): Partial<Omit<UseQuery<ReturnType>, 'refresh' | 'updated'>> {
+  result: RenderResult<DbQuery<ReturnType>>
+): Partial<Omit<DbQuery<ReturnType>, 'refresh' | 'updated'>> {
   return {
     data: result.current.data,
     isLoading: result.current.isLoading,
@@ -51,7 +51,7 @@ function extractResult(
   };
 }
 
-function isUpdatedAccurate(result: RenderResult<UseQuery<ReturnType>>, gt = 0, lt = Date.now()) {
+function isUpdatedAccurate(result: RenderResult<DbQuery<ReturnType>>, gt = 0, lt = Date.now()) {
   return result.current.updated > gt && result.current.updated <= lt;
 }
 

--- a/__tests__/ui/hooks/useDbQuery.test.ts
+++ b/__tests__/ui/hooks/useDbQuery.test.ts
@@ -4,7 +4,7 @@
 import { act, RenderResult } from '@testing-library/react-hooks';
 import { jest } from '@jest/globals';
 import type { OrFalsy, OrNull, UseQuery } from 'types';
-import { useQuery } from 'ui/hooks/useQuery';
+import { useDbQuery } from 'ui/hooks/useDbQuery';
 import { customRenderHook, timeout } from 'test-utils';
 
 interface ReturnType {
@@ -64,7 +64,7 @@ afterEach(() => {
 });
 
 test('should initialize correctly', () => {
-  const [{ result }] = customRenderHook(() => useQuery(mockQuery(0)), {}, { isDbReady: true });
+  const [{ result }] = customRenderHook(() => useDbQuery(mockQuery(0)), {}, { isDbReady: true });
 
   expect(extractResult(result)).toStrictEqual({ data: null, isLoading: true, isValid: true });
 
@@ -73,7 +73,7 @@ test('should initialize correctly', () => {
 
 test('should fetch data after initial mount', async () => {
   const [{ rerender, result, waitForValueToChange }] = customRenderHook(
-    () => useQuery(mockQuery(0)),
+    () => useDbQuery(mockQuery(0)),
     {},
     { isDbReady: true }
   );
@@ -93,7 +93,7 @@ test('should fetch data after initial mount', async () => {
 
 test('should handle query errors', async () => {
   const [{ result, rerender, waitForNextUpdate }] = customRenderHook(
-    () => useQuery(mockQuery(2)),
+    () => useDbQuery(mockQuery(2)),
     {},
     { isDbReady: true }
   );
@@ -110,7 +110,7 @@ test('should refresh automatically when query is changed', async () => {
   let query = mockQuery(0);
 
   const [{ result, rerender, waitForValueToChange }] = customRenderHook(
-    () => useQuery(query),
+    () => useDbQuery(query),
     {},
     { isDbReady: true }
   );
@@ -146,7 +146,7 @@ test('should provide working manual refresh callback', async () => {
   canReturnValid = false;
 
   const [{ result, rerender, waitForNextUpdate, waitForValueToChange }] = customRenderHook(
-    () => useQuery(mockQuery(0)),
+    () => useDbQuery(mockQuery(0)),
     {},
     { isDbReady: true }
   );
@@ -181,7 +181,7 @@ test('should provide working manual refresh callback', async () => {
 
 test('accepts a custom validate function', async () => {
   const [{ result, rerender, waitForNextUpdate }] = customRenderHook(
-    () => useQuery(mockQuery(0), validate),
+    () => useDbQuery(mockQuery(0), validate),
     {},
     { isDbReady: true }
   );

--- a/src/api/instantiate/createInstantiateTx.ts
+++ b/src/api/instantiate/createInstantiateTx.ts
@@ -18,7 +18,6 @@ export function createInstantiateTx(
     salt,
   }: InstantiateData
 ): SubmittableExtrinsic<'promise'> | null {
-  const isFromHash = !!codeHash;
   const saltu8a = encodeSalt(salt);
 
   const options = {
@@ -26,13 +25,12 @@ export function createInstantiateTx(
     salt: saltu8a,
     value: endowment ? api.registry.createType('Balance', endowment) : undefined,
   };
-  console.log(options);
 
   const wasm = metadata?.info.source.wasm;
-  const isValid = isFromHash || !!wasm;
+  const isValid = codeHash || !!wasm;
 
   if (isValid && metadata && isNumber(constructorIndex) && metadata && argValues) {
-    const codeOrBlueprint = isFromHash
+    const codeOrBlueprint = codeHash
       ? new BlueprintPromise(api, metadata, codeHash)
       : new CodePromise(api, metadata, wasm && wasm.toU8a());
 

--- a/src/api/instantiate/createInstantiateTx.ts
+++ b/src/api/instantiate/createInstantiateTx.ts
@@ -4,27 +4,27 @@
 import { BlueprintPromise, CodePromise } from '@polkadot/api-contract';
 import { isNumber } from '@polkadot/util';
 import { encodeSalt, transformUserInput } from '../util';
-import type { ApiPromise, InstantiateState, SubmittableExtrinsic } from 'types';
+import type { ApiPromise, InstantiateData, SubmittableExtrinsic } from 'types';
 
 export function createInstantiateTx(
   api: ApiPromise,
   {
-    argValues: [argValues],
+    argValues,
     codeHash,
-    constructorIndex: { value: constructorIndex },
-    weight: { weight: gasLimit },
+    constructorIndex,
+    weight: gasLimit,
     endowment,
-    metadata: { value: metadata },
+    metadata,
     salt,
-  }: InstantiateState
+  }: InstantiateData
 ): SubmittableExtrinsic<'promise'> | null {
   const isFromHash = !!codeHash;
-  const saltu8a = encodeSalt(salt.value);
+  const saltu8a = encodeSalt(salt);
 
   const options = {
     gasLimit,
     salt: saltu8a,
-    value: endowment.value ? api.registry.createType('Balance', endowment.value) : undefined,
+    value: endowment ? api.registry.createType('Balance', endowment) : undefined,
   };
   console.log(options);
 

--- a/src/api/instantiate/instantiate.ts
+++ b/src/api/instantiate/instantiate.ts
@@ -3,18 +3,20 @@
 
 import { handleDispatchError } from '../util';
 import type {
-  InstantiateState,
   ApiState,
   DbState,
   OnInstantiateSuccess$Code,
   OnInstantiateSuccess$Hash,
+  InstantiateData,
+  InstantiateState,
 } from 'types';
 import { createContract } from 'db';
 
 export function onInsantiateFromHash(
   { api, blockZeroHash }: ApiState,
   { db, identity }: DbState,
-  { data: { accountId, codeHash, name } }: InstantiateState
+  { accountId, codeHash, name }: InstantiateData,
+  onSuccess: InstantiateState['onSuccess']
 ): OnInstantiateSuccess$Hash {
   return async function ({ contract, dispatchError, status }): Promise<void> {
     if (dispatchError) {
@@ -33,7 +35,7 @@ export function onInsantiateFromHash(
         tags: [],
       });
 
-      // onSuccess && onSuccess(contract);
+      onSuccess && onSuccess(contract);
     }
   };
 }
@@ -41,7 +43,8 @@ export function onInsantiateFromHash(
 export function onInstantiateFromCode(
   { api, blockZeroHash }: ApiState,
   { db, identity }: DbState,
-  { data: { accountId, name } }: InstantiateState
+  { accountId, name }: InstantiateData,
+  onSuccess: InstantiateState['onSuccess']
 ): OnInstantiateSuccess$Code {
   return async function (result): Promise<void> {
     try {
@@ -62,7 +65,7 @@ export function onInstantiateFromCode(
           name: name,
           tags: [],
         });
-        // onSuccess && onSuccess(contract, blueprint);
+        onSuccess && onSuccess(contract, blueprint);
       }
     } catch (e) {
       console.error(e);

--- a/src/api/instantiate/instantiate.ts
+++ b/src/api/instantiate/instantiate.ts
@@ -14,26 +14,26 @@ import { createContract } from 'db';
 export function onInsantiateFromHash(
   { api, blockZeroHash }: ApiState,
   { db, identity }: DbState,
-  { accountId, codeHash, name, onSuccess }: InstantiateState
+  { data: { accountId, codeHash, name } }: InstantiateState
 ): OnInstantiateSuccess$Hash {
   return async function ({ contract, dispatchError, status }): Promise<void> {
     if (dispatchError) {
       handleDispatchError(dispatchError, api);
     }
 
-    if (accountId.value && codeHash && contract && (status.isInBlock || status.isFinalized)) {
+    if (accountId && codeHash && contract && (status.isInBlock || status.isFinalized)) {
       await createContract(db, identity, {
-        abi: contract.abi.json as Record<string, unknown>,
+        abi: contract.abi.json,
         address: contract.address.toString(),
-        creator: accountId.value,
+        creator: accountId,
         blockZeroHash: blockZeroHash || undefined,
         codeHash,
         genesisHash: api?.genesisHash.toString(),
-        name: name.value,
+        name: name,
         tags: [],
       });
 
-      onSuccess && onSuccess(contract);
+      // onSuccess && onSuccess(contract);
     }
   };
 }
@@ -41,7 +41,7 @@ export function onInsantiateFromHash(
 export function onInstantiateFromCode(
   { api, blockZeroHash }: ApiState,
   { db, identity }: DbState,
-  { accountId, name, onSuccess }: InstantiateState
+  { data: { accountId, name } }: InstantiateState
 ): OnInstantiateSuccess$Code {
   return async function (result): Promise<void> {
     try {
@@ -51,18 +51,18 @@ export function onInstantiateFromCode(
         handleDispatchError(dispatchError, api);
       }
 
-      if (accountId.value && contract && (status.isInBlock || status.isFinalized)) {
+      if (accountId && contract && (status.isInBlock || status.isFinalized)) {
         await createContract(db, identity, {
-          abi: contract.abi.json as Record<string, unknown>,
+          abi: contract.abi.json,
           address: contract.address.toString(),
           blockZeroHash: blockZeroHash || undefined,
-          creator: accountId.value,
+          creator: accountId,
           codeHash: blueprint?.codeHash.toHex() || contract.abi.info.source.wasmHash.toHex(),
           genesisHash: api?.genesisHash.toString(),
-          name: name.value,
+          name: name,
           tags: [],
         });
-        onSuccess && onSuccess(contract, blueprint);
+        // onSuccess && onSuccess(contract, blueprint);
       }
     } catch (e) {
       console.error(e);

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -4,7 +4,7 @@
 import React from 'react';
 import type { Collection, Database } from '@textile/threaddb';
 import type { PrivateKey } from '@textile/crypto';
-import type { VoidFn } from './substrate';
+import type { VoidFn, AnyJson } from './substrate';
 
 export type { Collection, Database, PrivateKey };
 
@@ -22,7 +22,7 @@ export interface UserDocument extends Document {
 }
 
 export interface CodeBundleDocument extends Document {
-  abi?: Record<string, unknown> | null;
+  abi?: AnyJson;
   blockZeroHash?: string;
   codeHash: string;
   creator: string;
@@ -37,7 +37,7 @@ export interface CodeBundleDocument extends Document {
 }
 
 export interface ContractDocument extends Document {
-  abi: Record<string, unknown>;
+  abi: AnyJson;
   address: string;
   blockZeroHash?: string;
   codeHash: string;

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -50,7 +50,7 @@ export interface ContractDocument extends Document {
   tags?: string[];
 }
 
-export interface UseQuery<T> {
+export interface DbQuery<T> {
   data: T | null;
   error: React.ReactNode | null;
   isLoading: boolean;
@@ -58,7 +58,10 @@ export interface UseQuery<T> {
   refresh: VoidFn;
   updated: number;
 }
-
+export type CodeBundle = {
+  document: CodeBundleDocument | null;
+  isOnChain: boolean;
+};
 export interface CodeBundleQuery {
   codeHash: string;
   blockZeroHash?: string | null;

--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -4,10 +4,10 @@
 import type {
   Abi,
   ApiPromise,
-  // BlueprintPromise,
+  BlueprintPromise,
   BlueprintSubmittableResult,
   CodeSubmittableResult,
-  // ContractPromise,
+  ContractPromise,
   Keyring,
   SubmittableExtrinsic,
   SubmittableResult,
@@ -62,14 +62,16 @@ export interface InstantiateData {
 export interface InstantiateState {
   data: InstantiateData;
   setData?: React.Dispatch<React.SetStateAction<InstantiateData>>;
-  // onError: () => void;
-  // onFinalize?: () => void;
-  // onUnFinalize?: () => void;
-  // onSuccess: (_: ContractPromise, __?: BlueprintPromise | undefined) => void;
+  onError: () => void;
+  onFinalize?: (data: Partial<InstantiateData>) => void;
+  onUnFinalize?: () => void;
+  onSuccess: (_: ContractPromise, __?: BlueprintPromise | undefined) => void;
+  onInstantiate: OnInstantiateSuccess$Code | OnInstantiateSuccess$Hash;
   currentStep: number;
   stepForward?: VoidFn;
   stepBackward?: VoidFn;
-  // tx: SubmittableExtrinsic<'promise'> | null;
+  setStep?: React.Dispatch<number>;
+  tx: SubmittableExtrinsic<'promise'> | null;
   // txError: string | null;
 }
 

--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -2,25 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
-  AbiConstructor,
+  Abi,
   ApiPromise,
-  BlueprintPromise,
+  // BlueprintPromise,
   BlueprintSubmittableResult,
   CodeSubmittableResult,
-  ContractPromise,
+  // ContractPromise,
   Keyring,
   SubmittableExtrinsic,
   SubmittableResult,
+  VoidFn,
 } from '../substrate';
-import type {
-  UseBalance,
-  UseFormField,
-  UseMetadata,
-  UseStepper,
-  UseToggle,
-  UseWeight,
-} from './hooks';
-import type { FileState, UseState } from './util';
+// import type { UseFormField, UseStepper, UseToggle, UseWeight } from './hooks';
+import type { BN } from './util';
 
 type Status = 'CONNECT_INIT' | 'CONNECTING' | 'READY' | 'ERROR' | 'LOADING';
 
@@ -54,29 +48,29 @@ export interface ChainProperties {
 export type OnInstantiateSuccess$Code = (_: CodeSubmittableResult<'promise'>) => Promise<void>;
 export type OnInstantiateSuccess$Hash = (_: BlueprintSubmittableResult<'promise'>) => Promise<void>;
 
+export interface InstantiateData {
+  accountId?: string;
+  argValues?: Record<string, unknown>;
+  endowment: BN;
+  metadata?: Abi;
+  name: string;
+  constructorIndex: number;
+  salt?: string;
+  weight: BN;
+  codeHash?: string;
+}
 export interface InstantiateState {
-  accountId: UseFormField<string | null>;
-  argValues: UseState<Record<string, unknown>>;
-  codeHash?: string | null;
-  constructorIndex: UseFormField<number>;
-  deployConstructor: AbiConstructor | null;
-  endowment: UseBalance;
-  isLoading: boolean;
-  isUsingSalt: UseToggle;
-  isUsingStoredMetadata: boolean;
-  metadata: UseMetadata;
-  metadataFile: UseState<FileState | undefined>;
-  name: UseFormField<string>;
-  onError: () => void;
-  onFinalize?: () => void;
-  onUnFinalize?: () => void;
-  onInstantiate: OnInstantiateSuccess$Code | OnInstantiateSuccess$Hash;
-  onSuccess: (_: ContractPromise, __?: BlueprintPromise | undefined) => void;
-  salt: UseFormField<string>;
-  step: UseStepper;
-  weight: UseWeight;
-  tx: SubmittableExtrinsic<'promise'> | null;
-  txError: string | null;
+  data: InstantiateData;
+  setData?: React.Dispatch<React.SetStateAction<InstantiateData>>;
+  // onError: () => void;
+  // onFinalize?: () => void;
+  // onUnFinalize?: () => void;
+  // onSuccess: (_: ContractPromise, __?: BlueprintPromise | undefined) => void;
+  currentStep: number;
+  stepForward?: VoidFn;
+  stepBackward?: VoidFn;
+  // tx: SubmittableExtrinsic<'promise'> | null;
+  // txError: string | null;
 }
 
 export type InstantiateProps = InstantiateState;

--- a/src/types/ui/hooks.ts
+++ b/src/types/ui/hooks.ts
@@ -4,7 +4,7 @@
 import { VoidFn } from '../substrate';
 import { BN, FileState, MetadataState, SetState, Validation } from './util';
 
-export interface UseWeight {
+export type UseWeight = {
   executionTime: number;
   isEmpty: boolean;
   isValid: boolean;
@@ -13,14 +13,14 @@ export interface UseWeight {
   setIsEmpty: SetState<boolean>;
   setMegaGas: React.Dispatch<BN | undefined>;
   weight: BN;
-}
+};
 
 export interface UseFormField<T> extends Validation {
-  value?: T;
+  value: T;
   onChange: (_: T) => void;
 }
 
-export type UseBalance = UseFormField<BN | null | undefined>;
+export type UseBalance = UseFormField<BN>;
 
 export interface UseMetadata extends MetadataState {
   onChange: (_: FileState) => void;

--- a/src/types/ui/util.ts
+++ b/src/types/ui/util.ts
@@ -36,8 +36,8 @@ export interface FileState {
 }
 
 export interface MetadataState extends Validation {
-  source: AnyJson | null;
-  name: string | null;
-  value: Abi | null;
+  source: AnyJson;
+  name: string;
+  value?: Abi;
   isSupplied: boolean;
 }

--- a/src/ui/components/account/AccountSelect.tsx
+++ b/src/ui/components/account/AccountSelect.tsx
@@ -8,9 +8,9 @@ import { createAccountOptions } from 'api/util';
 import type { DropdownProps, OptionProps, UseFormField } from 'types';
 import { useApi } from 'ui/contexts';
 
-type Props = UseFormField<string | null> & Omit<DropdownProps<string | null>, 'options'>;
+type Props = UseFormField<string> & Omit<DropdownProps<string>, 'options'>;
 
-function Option({ option: { name, value } }: OptionProps<string | null>) {
+function Option({ option: { name, value } }: OptionProps<string>) {
   return <Account name={name} value={value} />;
 }
 

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -27,7 +27,7 @@ export const InteractTab = ({ contract }: Props) => {
   const [argValues, setArgValues] = useArgValues(message.value?.args || []);
   const [state, dispatch] = useReducer(contractCallReducer, initialState);
   const [endowment, setEndowment] = useState('');
-  const accountId = useAccountId();
+  const { value: accountId, onChange: setAccountId, ...accountIdValidation } = useAccountId();
 
   useEffect(() => {
     if (state.results.length > 0) {
@@ -47,8 +47,13 @@ export const InteractTab = ({ contract }: Props) => {
     <div className="grid grid-cols-12 w-full">
       <div className="col-span-6 lg:col-span-7 2xl:col-span-8 rounded-lg w-full">
         <Form>
-          <FormField className="mb-8" id="accountId" label="Account" {...getValidation(accountId)}>
-            <AccountSelect id="accountId" className="mb-2" {...accountId} />
+          <FormField className="mb-8" id="accountId" label="Account" {...accountIdValidation}>
+            <AccountSelect
+              id="accountId"
+              className="mb-2"
+              value={accountId}
+              onChange={setAccountId}
+            />
           </FormField>
           <FormField id="message" label="Message to Send" {...getValidation(message)}>
             <Dropdown
@@ -88,7 +93,7 @@ export const InteractTab = ({ contract }: Props) => {
                 gasLimit: 155852802980,
                 argValues,
                 message: message.value,
-                keyringPair: accountId.value ? keyring?.getPair(accountId.value) : undefined,
+                keyringPair: accountId ? keyring?.getPair(accountId) : undefined,
                 dispatch,
               })
             }

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -12,7 +12,7 @@ import { ResultsOutput } from './ResultsOutput';
 import { call, convertToNumber, createMessageOptions } from 'api';
 import { useApi } from 'ui/contexts';
 import { contractCallReducer, initialState } from 'ui/reducers';
-import { AbiMessage, ContractPromise } from 'types';
+import { ContractPromise } from 'types';
 import { useAccountId } from 'ui/hooks/useAccountId';
 import { useFormField } from 'ui/hooks/useFormField';
 import { useArgValues } from 'ui/hooks/useArgValues';
@@ -87,7 +87,7 @@ export const InteractTab = ({ contract }: Props) => {
                 endowment: convertToNumber(endowment.trim()),
                 gasLimit: 155852802980,
                 argValues,
-                message: message.value as AbiMessage,
+                message: message.value,
                 keyringPair: accountId.value ? keyring?.getPair(accountId.value) : undefined,
                 dispatch,
               })

--- a/src/ui/components/form/CodeHashField.tsx
+++ b/src/ui/components/form/CodeHashField.tsx
@@ -1,0 +1,17 @@
+// Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { CodeHash } from '../instantiate/CodeHash';
+import { FormField } from './FormField';
+
+interface Props {
+  codeHash: string;
+  name: string;
+}
+
+export const CodeHashField = ({ codeHash, name }: Props) => (
+  <FormField id="metadata" label="On-Chain Code">
+    <CodeHash codeHash={codeHash} name={name} />
+  </FormField>
+);

--- a/src/ui/components/form/InputBalance.tsx
+++ b/src/ui/components/form/InputBalance.tsx
@@ -12,8 +12,8 @@ import { useApi } from 'ui/contexts';
 type Props = SimpleSpread<
   React.InputHTMLAttributes<HTMLInputElement>,
   {
-    value?: BN | null;
-    onChange: (_?: BN | null) => void;
+    value: BN;
+    onChange: (_: BN) => void;
   }
 >;
 

--- a/src/ui/components/form/hooks/useAccountField.tsx
+++ b/src/ui/components/form/hooks/useAccountField.tsx
@@ -1,0 +1,19 @@
+// Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { AccountSelect } from '../../account/AccountSelect';
+import { FormField } from '../FormField';
+import { useAccountId } from 'ui/hooks/useAccountId';
+
+export const useAccountSelect = () => {
+  const { value: accountId, onChange: setAccountId, ...accountIdValidation } = useAccountId();
+
+  const AccountSelectField = () => (
+    <FormField className="mb-8" id="accountId" label="Account" {...accountIdValidation}>
+      <AccountSelect id="accountId" className="mb-2" value={accountId} onChange={setAccountId} />
+    </FormField>
+  );
+  return { accountId, AccountSelectField };
+};

--- a/src/ui/components/form/hooks/useContractName.tsx
+++ b/src/ui/components/form/hooks/useContractName.tsx
@@ -1,0 +1,24 @@
+// Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { FormField } from '../FormField';
+import { Input } from '../Input';
+import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
+
+export const useContractName = () => {
+  const { value: name, onChange: setName, ...nameValidation } = useNonEmptyString();
+  const ContractNameField = () => {
+    return (
+      <FormField id="name" label="Contract Name" {...nameValidation}>
+        <Input
+          id="contractName"
+          placeholder="Give your contract a descriptive name"
+          value={name}
+          onChange={setName}
+        />
+      </FormField>
+    );
+  };
+  return { name, setName, ContractNameField, nameValidation };
+};

--- a/src/ui/components/form/hooks/useMetadataField.tsx
+++ b/src/ui/components/form/hooks/useMetadataField.tsx
@@ -1,0 +1,66 @@
+// Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState, useMemo, useEffect } from 'react';
+import { useParams, useHistory } from 'react-router';
+import { FormField, getValidation } from '../FormField';
+import { InputFile } from '../InputFile';
+import { FileState } from 'types';
+import { useMetadata } from 'ui/hooks/useMetadata';
+import { useCodeBundle } from 'ui/hooks/useCodeBundle';
+
+export const useMetadataField = () => {
+  const history = useHistory();
+  const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
+
+  const [metadataFile, setMetadataFile] = useState<FileState>();
+
+  const codeBundleQuery = useCodeBundle(codeHashUrlParam);
+  const codeBundle = codeBundleQuery.data;
+  const metadata = useMetadata(codeBundle?.document?.abi, {
+    isWasmRequired: !codeBundle,
+    onChange: setMetadataFile,
+  });
+
+  const isLoadingCodeBundle = useMemo(
+    () => !!codeHashUrlParam && codeBundleQuery.isLoading,
+    [codeHashUrlParam, codeBundleQuery.isLoading]
+  );
+
+  const isUsingStoredMetadata = useMemo(
+    (): boolean => !!codeBundle?.document,
+    [codeBundle?.document]
+  );
+
+  useEffect((): void => {
+    if (codeHashUrlParam && !codeBundleQuery.isValid) {
+      history.replace('/instantiate/hash');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [codeHashUrlParam, codeBundleQuery.isValid]);
+
+  const MetadataField = () => {
+    return (
+      <FormField
+        id="metadata"
+        label={codeHashUrlParam ? 'Upload Metadata' : 'Upload Contract Bundle'}
+        {...getValidation(metadata)}
+      >
+        <InputFile
+          placeholder="Click to select or drag & drop to upload file."
+          onChange={metadata.onChange}
+          onRemove={metadata.onRemove}
+          isError={metadata.isError}
+          value={metadataFile}
+        />
+      </FormField>
+    );
+  };
+  return {
+    isLoadingCodeBundle,
+    isUsingStoredMetadata,
+    MetadataField,
+    metadata: metadata.value,
+    isErrorMetadata: metadata.isError,
+  };
+};

--- a/src/ui/components/form/index.ts
+++ b/src/ui/components/form/index.ts
@@ -8,4 +8,8 @@ export * from './InputFile';
 export * from './InputNumber';
 export * from './InputSalt';
 export * from './ArgumentForm';
+export * from './CodeHashField';
 export * from './Bool';
+export * from './hooks/useAccountField';
+export * from './hooks/useContractName';
+export * from './hooks/useMetadataField';

--- a/src/ui/components/instantiate/LookUpCodeHash.tsx
+++ b/src/ui/components/instantiate/LookUpCodeHash.tsx
@@ -17,8 +17,7 @@ export function LookUpCodeHash() {
   const [codeHash, setCodeHash] = useState<string | null>(null);
   const { data: searchResults } = useCodeBundleSearch(searchString);
   const { data, error, isLoading, isValid } = useCodeBundle(codeHash);
-  const [isOnChain, document] = !!data && !isLoading ? data : [false, null];
-
+  const { isOnChain, document } = data || { document: null, isOnChain: false };
   useEffect((): void => {
     if (codeHash !== searchString) {
       if (searchString === '' || isValidCodeHash(searchString)) {

--- a/src/ui/components/instantiate/LookUpCodeHash.tsx
+++ b/src/ui/components/instantiate/LookUpCodeHash.tsx
@@ -14,7 +14,7 @@ import { classes, isValidCodeHash } from 'ui/util';
 export function LookUpCodeHash() {
   const history = useHistory();
   const [searchString, setSearchString] = useState('');
-  const [codeHash, setCodeHash] = useState<string | null>(null);
+  const [codeHash, setCodeHash] = useState('');
   const { data: searchResults } = useCodeBundleSearch(searchString);
   const { data, error, isLoading, isValid } = useCodeBundle(codeHash);
   const { isOnChain, document } = data || { document: null, isOnChain: false };
@@ -23,7 +23,7 @@ export function LookUpCodeHash() {
       if (searchString === '' || isValidCodeHash(searchString)) {
         setCodeHash(searchString);
       } else {
-        setCodeHash(null);
+        setCodeHash('');
       }
     }
   }, [codeHash, searchString]);

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -20,9 +20,10 @@ import { FileState } from 'types';
 
 export function Step1() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
+  const history = useHistory();
+
   const { stepForward, setData, data, currentStep } = useInstantiate();
 
-  const history = useHistory();
   const codeBundleQuery = useCodeBundle(codeHashUrlParam);
   const codeBundle = codeBundleQuery.data;
 
@@ -32,14 +33,17 @@ export function Step1() {
     () => !!codeHashUrlParam && codeBundleQuery.isLoading,
     [codeHashUrlParam, codeBundleQuery.isLoading]
   );
+
   const isUsingStoredMetadata = useMemo(
     (): boolean => !!codeBundle?.document,
     [codeBundle?.document]
   );
+
   const metadata = useMetadata(codeBundle?.document?.abi, {
     isWasmRequired: !codeBundle,
     onChange: setMetadataFile,
   });
+
   const { value: accountId, onChange: setAccountId, ...accountIdValidation } = useAccountId();
 
   const { value: name, onChange: setName, ...nameValidation } = useNonEmptyString();
@@ -61,6 +65,7 @@ export function Step1() {
     setData &&
       setData({
         ...data,
+        accountId,
         metadata: metadata?.value,
         name,
         codeHash: codeHashUrlParam || undefined,

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -20,7 +20,7 @@ import { FileState } from 'types';
 
 export function Step1() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
-  const { stepForward, setData, data } = useInstantiate();
+  const { stepForward, setData, data, currentStep } = useInstantiate();
 
   const history = useHistory();
   const codeBundleQuery = useCodeBundle(codeHashUrlParam);
@@ -68,6 +68,8 @@ export function Step1() {
 
     stepForward && stepForward();
   }
+
+  if (currentStep !== 1) return null;
 
   return (
     <Loader isLoading={isLoading}>

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -1,72 +1,35 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useMemo, useState } from 'react';
-import { useParams, useHistory } from 'react-router';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router';
 import { Button, Buttons } from '../common/Button';
-import { Form, FormField, getValidation } from '../form/FormField';
+import { Form, useAccountSelect, useContractName, useMetadataField, CodeHashField } from '../form';
 import { Loader } from '../common/Loader';
-import { AccountSelect } from '../account/AccountSelect';
-import { CodeHash } from './CodeHash';
-import { InputFile } from 'ui/components/form/InputFile';
-import { Input } from 'ui/components/form/Input';
 import { useInstantiate } from 'ui/contexts';
-import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
-import { useCodeBundle } from 'ui/hooks/useCodeBundle';
-import { useMetadata } from 'ui/hooks/useMetadata';
-import { useAccountId } from 'ui/hooks/useAccountId';
-
-import { FileState } from 'types';
 
 export function Step1() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
-  const history = useHistory();
 
   const { stepForward, setData, data, currentStep } = useInstantiate();
 
-  const codeBundleQuery = useCodeBundle(codeHashUrlParam);
-  const codeBundle = codeBundleQuery.data;
-
-  const [metadataFile, setMetadataFile] = useState<FileState>();
-
-  const isLoading = useMemo(
-    () => !!codeHashUrlParam && codeBundleQuery.isLoading,
-    [codeHashUrlParam, codeBundleQuery.isLoading]
-  );
-
-  const isUsingStoredMetadata = useMemo(
-    (): boolean => !!codeBundle?.document,
-    [codeBundle?.document]
-  );
-
-  const metadata = useMetadata(codeBundle?.document?.abi, {
-    isWasmRequired: !codeBundle,
-    onChange: setMetadataFile,
-  });
-
-  const { value: accountId, onChange: setAccountId, ...accountIdValidation } = useAccountId();
-
-  const { value: name, onChange: setName, ...nameValidation } = useNonEmptyString();
+  const { accountId, AccountSelectField } = useAccountSelect();
+  const { name, setName, ContractNameField, nameValidation } = useContractName();
+  const { metadata, isLoadingCodeBundle, isUsingStoredMetadata, isErrorMetadata, MetadataField } =
+    useMetadataField();
 
   useEffect((): void => {
-    if (metadata.value?.info.contract.name && !name) {
-      setName(metadata.value?.info.contract.name.toString());
+    if (metadata?.info.contract.name && !name) {
+      setName(metadata?.info.contract.name.toString());
     }
-  }, [metadata.value, name, setName]);
+  }, [metadata, name, setName]);
 
-  useEffect((): void => {
-    if (codeHashUrlParam && !codeBundleQuery.isValid) {
-      history.replace('/instantiate/hash');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [codeHashUrlParam, codeBundleQuery.isValid]);
-
-  function moveToNextStep() {
+  function submitStep1() {
     setData &&
       setData({
         ...data,
         accountId,
-        metadata: metadata?.value,
+        metadata: metadata,
         name,
         codeHash: codeHashUrlParam || undefined,
       });
@@ -77,56 +40,26 @@ export function Step1() {
   if (currentStep !== 1) return null;
 
   return (
-    <Loader isLoading={isLoading}>
+    <Loader isLoading={isLoadingCodeBundle}>
       <Form>
-        <FormField className="mb-8" id="accountId" label="Account" {...accountIdValidation}>
-          <AccountSelect
-            id="accountId"
-            className="mb-2"
-            value={accountId}
-            onChange={setAccountId}
-          />
-        </FormField>
-        <FormField id="name" label="Contract Name" {...nameValidation}>
-          <Input
-            id="contractName"
-            placeholder="Give your contract a descriptive name"
-            value={name}
-            onChange={setName}
-          />
-        </FormField>
+        <AccountSelectField />
+        <ContractNameField />
         {codeHashUrlParam && (
-          <FormField id="metadata" label="On-Chain Code">
-            <CodeHash
-              codeHash={codeHashUrlParam}
-              name={
-                isUsingStoredMetadata
-                  ? metadata.value?.info.contract.name.toString()
-                  : 'Unidentified Code'
-              }
-            />
-          </FormField>
+          <CodeHashField
+            codeHash={codeHashUrlParam}
+            name={
+              isUsingStoredMetadata
+                ? metadata?.info?.contract.name.toString() || 'Contract'
+                : 'Unidentified Code'
+            }
+          />
         )}
-        {(!codeHashUrlParam || !isUsingStoredMetadata) && (
-          <FormField
-            id="metadata"
-            label={codeHashUrlParam ? 'Upload Metadata' : 'Upload Contract Bundle'}
-            {...getValidation(metadata)}
-          >
-            <InputFile
-              placeholder="Click to select or drag & drop to upload file."
-              onChange={metadata.onChange}
-              onRemove={metadata.onRemove}
-              isError={metadata.isError}
-              value={metadataFile}
-            />
-          </FormField>
-        )}
+        {(!codeHashUrlParam || !isUsingStoredMetadata) && <MetadataField />}
       </Form>
       <Buttons>
         <Button
-          isDisabled={!metadata.value || !nameValidation.isValid || metadata.isError}
-          onClick={moveToNextStep}
+          isDisabled={!metadata || !nameValidation.isValid || isErrorMetadata}
+          onClick={submitStep1}
           variant="primary"
         >
           Next

--- a/src/ui/components/instantiate/Step2.tsx
+++ b/src/ui/components/instantiate/Step2.tsx
@@ -24,6 +24,7 @@ export function Step2() {
   const {
     data: { metadata },
     stepBackward,
+    currentStep,
   } = useInstantiate();
   const {
     value: endowment,
@@ -50,6 +51,8 @@ export function Step2() {
   );
   const [argValues, setArgValues] = useArgValues(deployConstructor?.args || []);
   const [isUsingSalt, toggleIsUsingSalt] = useToggle();
+
+  if (currentStep !== 2) return null;
 
   return metadata ? (
     <>

--- a/src/ui/components/instantiate/Step2.tsx
+++ b/src/ui/components/instantiate/Step2.tsx
@@ -1,35 +1,57 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
-import type { AbiConstructor } from '@polkadot/api-contract/types';
+import React, { useMemo } from 'react';
+import { isNumber, isHex } from '@polkadot/util';
+import { randomAsHex } from '@polkadot/util-crypto';
 import { Button, Buttons } from '../common/Button';
 import { Form, FormField, getValidation } from '../form/FormField';
 import { InputNumber } from '../form/InputNumber';
 import { InputBalance } from '../form/InputBalance';
 import { InputSalt } from '../form/InputSalt';
+import type { AbiConstructor } from 'types';
 import { ArgumentForm } from 'ui/components/form/ArgumentForm';
 import { Dropdown } from 'ui/components/common/Dropdown';
 import { createConstructorOptions } from 'api/util';
 import { useInstantiate } from 'ui/contexts';
+import { useBalance } from 'ui/hooks/useBalance';
+import { useArgValues } from 'ui/hooks/useArgValues';
+import { useFormField } from 'ui/hooks/useFormField';
+import { useWeight } from 'ui/hooks/useWeight';
+import { useToggle } from 'ui/hooks/useToggle';
 
 export function Step2() {
-  const state = useInstantiate();
-
   const {
-    argValues: [argValues, setArgValues],
-    constructorIndex,
-    deployConstructor,
-    endowment,
-    isUsingSalt: [isUsingSalt, toggleIsUsingSalt],
-    metadata,
-    onFinalize,
-    salt,
-    step: [, , stepBack],
-    weight: { executionTime, isValid: isWeightValid, megaGas, setMegaGas, percentage },
-  } = state;
+    data: { metadata },
+    stepBackward,
+  } = useInstantiate();
+  const {
+    value: endowment,
+    onChange: onChangeEndowment,
+    ...endowmentValidation
+  } = useBalance(10000);
+  const { executionTime, isValid: isWeightValid, megaGas, setMegaGas, percentage } = useWeight();
+  const salt = useFormField<string>(randomAsHex(), value => {
+    if (!!value && isHex(value) && value.length === 66) {
+      return { isValid: true };
+    }
 
-  return (
+    return { isValid: false, isError: true, message: 'Invalid hex string' };
+  });
+
+  const constructorIndex = useFormField(0);
+
+  const deployConstructor = useMemo(
+    (): AbiConstructor | null =>
+      isNumber(constructorIndex.value)
+        ? metadata?.constructors[constructorIndex.value] || null
+        : null,
+    [metadata, constructorIndex.value]
+  );
+  const [argValues, setArgValues] = useArgValues(deployConstructor?.args || []);
+  const [isUsingSalt, toggleIsUsingSalt] = useToggle();
+
+  return metadata ? (
     <>
       <Form>
         <FormField
@@ -39,7 +61,7 @@ export function Step2() {
         >
           <Dropdown
             id="constructor"
-            options={createConstructorOptions(metadata.value?.constructors as AbiConstructor[])}
+            options={createConstructorOptions(metadata.constructors)}
             className="mb-4"
             {...constructorIndex}
           >
@@ -54,8 +76,8 @@ export function Step2() {
             />
           )}
         </FormField>
-        <FormField id="endowment" label="Endowment" {...getValidation(endowment)}>
-          <InputBalance id="endowment" {...endowment} />
+        <FormField id="endowment" label="Endowment" {...endowmentValidation}>
+          <InputBalance id="endowment" value={endowment} onChange={onChangeEndowment} />
         </FormField>
         <FormField id="salt" label="Deployment Salt" {...getValidation(salt)}>
           <InputSalt isActive={isUsingSalt} toggleIsActive={toggleIsUsingSalt} {...salt} />
@@ -84,22 +106,22 @@ export function Step2() {
       <Buttons>
         <Button
           isDisabled={
-            !endowment.isValid ||
+            !endowmentValidation.isValid ||
             (isUsingSalt && !salt.isValid) ||
             !isWeightValid ||
             !deployConstructor?.method ||
             !argValues
           }
-          onClick={onFinalize}
+          // onClick={onFinalize}
           variant="primary"
         >
           Next
         </Button>
 
-        <Button onClick={stepBack} variant="default">
+        <Button onClick={stepBackward} variant="default">
           Go Back
         </Button>
       </Buttons>
     </>
-  );
+  ) : null;
 }

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -16,6 +16,7 @@ export function Step3() {
 
   const {
     data: { accountId, codeHash, endowment, metadata, weight, name },
+    currentStep,
   } = instantiateState;
 
   // const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
@@ -27,6 +28,8 @@ export function Step3() {
   // );
 
   const displayHash = codeHash || metadata?.info.source.wasmHash.toHex() || null;
+
+  if (currentStep !== 3) return null;
 
   return (
     <>

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -14,11 +14,11 @@ import { truncate } from 'ui/util';
 
 export function Step3() {
   const apiState = useApi();
-  const { codeHash } = useParams<{ codeHash: string }>();
+  const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
   const { data, currentStep, onUnFinalize, tx, onError, onInstantiate } = useInstantiate();
   const { accountId, endowment, metadata, weight, name } = data;
 
-  const displayHash = codeHash || metadata?.info.source.wasmHash.toHex() || null;
+  const displayHash = codeHashUrlParam || metadata?.info.source.wasmHash.toHex();
 
   const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
     tx,

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import { BN_ZERO, formatBalance, formatNumber } from '@polkadot/util';
 import { Account } from '../account/Account';
 import { Button, Buttons } from '../common/Button';
-import { isResultValid, useApi, useInstantiate } from 'ui/contexts';
-import { useQueueTx } from 'ui/hooks/useQueueTx';
+import { useApi, useInstantiate } from 'ui/contexts';
+// import { useQueueTx } from 'ui/hooks/useQueueTx';
 import { fromSats } from 'api';
 import { truncate } from 'ui/util';
 
@@ -15,27 +15,18 @@ export function Step3() {
   const instantiateState = useInstantiate();
 
   const {
-    accountId,
-    codeHash,
-    endowment,
-    metadata,
-    weight,
-    name,
-    onInstantiate,
-    onError,
-    onUnFinalize,
-    tx,
+    data: { accountId, codeHash, endowment, metadata, weight, name },
   } = instantiateState;
 
-  const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
-    tx,
-    accountId.value,
-    onInstantiate,
-    onError,
-    isResultValid
-  );
+  // const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
+  //   tx,
+  //   accountId.value,
+  //   onInstantiate,
+  //   onError,
+  //   isResultValid
+  // );
 
-  const displayHash = codeHash || metadata.value?.info.source.wasmHash.toHex() || null;
+  const displayHash = codeHash || metadata?.info.source.wasmHash.toHex() || null;
 
   return (
     <>
@@ -43,25 +34,25 @@ export function Step3() {
         <div className="field full">
           <p className="key">Account</p>
           <div className="value">
-            <Account className="p-0" value={accountId.value} />
+            <Account className="p-0" value={accountId} />
           </div>
         </div>
 
         <div className="field full">
           <p className="key">Name</p>
-          <p className="value">{name.value}</p>
+          <p className="value">{name}</p>
         </div>
 
         <div className="field">
           <p className="key">Endowment</p>
           <p className="value">
-            {formatBalance(fromSats(api, endowment?.value || BN_ZERO), { forceUnit: '-' })}
+            {formatBalance(fromSats(api, endowment || BN_ZERO), { forceUnit: '-' })}
           </p>
         </div>
 
         <div className="field">
           <p className="key">Weight</p>
-          <p className="value">{formatNumber(weight.weight)}</p>
+          <p className="value">{formatNumber(weight)}</p>
         </div>
 
         {displayHash && (
@@ -71,22 +62,22 @@ export function Step3() {
           </div>
         )}
 
-        {tx?.args[3] && (
+        {/* {tx?.args[3] && (
           <div className="field">
             <p className="key">Data</p>
             <p className="value">{tx?.args[3].toHex()}</p>
           </div>
-        )}
+        )} */}
       </div>
       <Buttons>
-        <Button variant="primary" isDisabled={!isValid} isLoading={isProcessing} onClick={onSubmit}>
+        {/* <Button variant="primary" isDisabled={!isValid} isLoading={isProcessing} onClick={onSubmit}>
           Upload and Instantiate
-        </Button>
+        </Button> */}
 
         <Button
           onClick={(): void => {
-            onCancel();
-            onUnFinalize && onUnFinalize();
+            // onCancel();
+            // onUnFinalize && onUnFinalize();
           }}
         >
           Go Back

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -2,32 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { BN_ZERO, formatBalance, formatNumber } from '@polkadot/util';
+import { formatBalance, formatNumber } from '@polkadot/util';
+import { useParams } from 'react-router';
 import { Account } from '../account/Account';
 import { Button, Buttons } from '../common/Button';
-import { useApi, useInstantiate } from 'ui/contexts';
-// import { useQueueTx } from 'ui/hooks/useQueueTx';
+import { useApi, useInstantiate, isResultValid } from 'ui/contexts';
+import { useQueueTx } from 'ui/hooks/useQueueTx';
+
 import { fromSats } from 'api';
 import { truncate } from 'ui/util';
 
 export function Step3() {
-  const { api } = useApi();
-  const instantiateState = useInstantiate();
-
-  const {
-    data: { accountId, codeHash, endowment, metadata, weight, name },
-    currentStep,
-  } = instantiateState;
-
-  // const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
-  //   tx,
-  //   accountId.value,
-  //   onInstantiate,
-  //   onError,
-  //   isResultValid
-  // );
+  const apiState = useApi();
+  const { codeHash } = useParams<{ codeHash: string }>();
+  const { data, currentStep, onUnFinalize, tx, onError, onInstantiate } = useInstantiate();
+  const { accountId, endowment, metadata, weight, name } = data;
 
   const displayHash = codeHash || metadata?.info.source.wasmHash.toHex() || null;
+
+  const [onSubmit, onCancel, isValid, isProcessing] = useQueueTx(
+    tx,
+    data.accountId,
+    onInstantiate,
+    onError,
+    isResultValid
+  );
 
   if (currentStep !== 3) return null;
 
@@ -49,7 +48,7 @@ export function Step3() {
         <div className="field">
           <p className="key">Endowment</p>
           <p className="value">
-            {formatBalance(fromSats(api, endowment || BN_ZERO), { forceUnit: '-' })}
+            {formatBalance(fromSats(apiState.api, endowment), { forceUnit: '-' })}
           </p>
         </div>
 
@@ -65,22 +64,22 @@ export function Step3() {
           </div>
         )}
 
-        {/* {tx?.args[3] && (
+        {tx?.args[3] && (
           <div className="field">
             <p className="key">Data</p>
             <p className="value">{tx?.args[3].toHex()}</p>
           </div>
-        )} */}
+        )}
       </div>
       <Buttons>
-        {/* <Button variant="primary" isDisabled={!isValid} isLoading={isProcessing} onClick={onSubmit}>
+        <Button variant="primary" isDisabled={!isValid} isLoading={isProcessing} onClick={onSubmit}>
           Upload and Instantiate
-        </Button> */}
+        </Button>
 
         <Button
           onClick={(): void => {
-            // onCancel();
-            // onUnFinalize && onUnFinalize();
+            onCancel();
+            onUnFinalize && onUnFinalize();
           }}
         >
           Go Back

--- a/src/ui/components/instantiate/Stepper.tsx
+++ b/src/ui/components/instantiate/Stepper.tsx
@@ -4,22 +4,25 @@
 import React from 'react';
 import { CheckIcon } from '@heroicons/react/outline';
 import { classes } from 'ui/util';
+import { useInstantiate } from 'ui/contexts';
+
+type Step = { name: string; index: number };
 
 interface Props {
-  step: number;
-  steps: string[];
+  steps: Step[];
 }
 
-export function Stepper({ step, steps }: Props) {
+export function Stepper({ steps }: Props) {
+  const { currentStep } = useInstantiate();
   return (
     <>
-      {steps.map((label, index) => {
-        const isFilled = index <= step;
-        const isCurrent = index === step;
+      {steps.map(({ name, index }) => {
+        const isFilled = index <= currentStep;
+        const isCurrent = index === currentStep;
 
         return (
-          <div key={`${label}`}>
-            {index > 0 ? (
+          <div key={`${name}`}>
+            {index > 1 ? (
               <div className="flex justify-center w-6 py-4">
                 <span
                   className={`h-8 ${isFilled ? 'bg-indigo-500' : 'bg-elevation-2'}`}
@@ -34,14 +37,14 @@ export function Stepper({ step, steps }: Props) {
                   'flex items-center justify-center text-white text-center text-sm rounded-md w-6 h-6 p-1'
                 )}
               >
-                {index < step ? (
+                {index < currentStep ? (
                   <CheckIcon className="bg-indigo-500 text-white text-lg rounded-md w-6" />
                 ) : (
-                  index + 1
+                  index
                 )}
               </div>
               <span className={classes('text-sm', isCurrent ? 'text-gray-200' : 'text-gray-500')}>
-                {label}
+                {name}
               </span>
             </div>
           </div>

--- a/src/ui/components/instantiate/Wizard.tsx
+++ b/src/ui/components/instantiate/Wizard.tsx
@@ -6,22 +6,23 @@ import { Step1 } from './Step1';
 import { Step2 } from './Step2';
 import { Step3 } from './Step3';
 import { Stepper } from './Stepper';
-import { CONTRACT_FILE, DEPLOYMENT_INFO, FINALIZE, useInstantiate } from 'ui/contexts';
 
-const steps = ['Contract Bundle', 'Deployment Info', 'Confirmation'];
+const steps = [
+  { name: 'Contract Bundle', index: 1 },
+  { name: 'Deployment Info', index: 2 },
+  { name: 'Confirmation', index: 3 },
+];
 
 export function Wizard() {
-  const { currentStep } = useInstantiate();
-
   return (
     <div className="grid md:grid-cols-12 gap-5 m-1">
       <main className="md:col-span-9 p-4">
-        {currentStep === CONTRACT_FILE && <Step1 />}
-        {currentStep === DEPLOYMENT_INFO && <Step2 />}
-        {currentStep === FINALIZE && <Step3 />}
+        <Step1 />
+        <Step2 />
+        <Step3 />
       </main>
       <aside className="md:col-span-3 md:pt-0 p-4">
-        <Stepper step={currentStep} steps={steps} />
+        <Stepper steps={steps} />
       </aside>
     </div>
   );

--- a/src/ui/components/instantiate/Wizard.tsx
+++ b/src/ui/components/instantiate/Wizard.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { FormField, getValidation } from '../form/FormField';
-import { AccountSelect } from '../account/AccountSelect';
 import { Step1 } from './Step1';
 import { Step2 } from './Step2';
 import { Step3 } from './Step3';
@@ -13,25 +11,17 @@ import { CONTRACT_FILE, DEPLOYMENT_INFO, FINALIZE, useInstantiate } from 'ui/con
 const steps = ['Contract Bundle', 'Deployment Info', 'Confirmation'];
 
 export function Wizard() {
-  const {
-    accountId,
-    step: [step],
-  } = useInstantiate();
+  const { currentStep } = useInstantiate();
 
   return (
     <div className="grid md:grid-cols-12 gap-5 m-1">
       <main className="md:col-span-9 p-4">
-        {step < 2 && (
-          <FormField className="mb-8" id="accountId" label="Account" {...getValidation(accountId)}>
-            <AccountSelect id="accountId" className="mb-2" {...accountId} />
-          </FormField>
-        )}
-        {step === CONTRACT_FILE && <Step1 />}
-        {step === DEPLOYMENT_INFO && <Step2 />}
-        {step === FINALIZE && <Step3 />}
+        {currentStep === CONTRACT_FILE && <Step1 />}
+        {currentStep === DEPLOYMENT_INFO && <Step2 />}
+        {currentStep === FINALIZE && <Step3 />}
       </main>
       <aside className="md:col-span-3 md:pt-0 p-4">
-        <Stepper step={step} steps={steps} />
+        <Stepper step={currentStep} steps={steps} />
       </aside>
     </div>
   );

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -1,47 +1,35 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useContext, useCallback, useMemo, useEffect } from 'react';
-import { useHistory, useParams } from 'react-router';
-import { randomAsHex } from '@polkadot/util-crypto';
-import { AbiConstructor } from '@polkadot/api-contract/types';
-import { isHex, isNumber } from '@polkadot/util';
-import { useApi } from './ApiContext';
-import { useDatabase } from './DatabaseContext';
-import { createInstantiateTx, onInsantiateFromHash, onInstantiateFromCode } from 'api/instantiate';
+import React, { useState, useContext } from 'react';
+// import { useHistory, useParams } from 'react-router';
+
+import { BN_THOUSAND } from '@polkadot/util';
+// import { useApi } from './ApiContext';
+// import { useDatabase } from './DatabaseContext';
+// import { createInstantiateTx, onInsantiateFromHash, onInstantiateFromCode } from 'api/instantiate';
 import {
-  AnyJson,
-  BlueprintPromise,
-  ContractPromise,
-  FileState,
+  // BlueprintPromise,
+  // ContractPromise,
   InstantiateProps,
   InstantiateState,
-  SubmittableExtrinsic,
-  OnInstantiateSuccess$Code,
-  OnInstantiateSuccess$Hash,
+  // SubmittableExtrinsic,
+  // OnInstantiateSuccess$Code,
+  // OnInstantiateSuccess$Hash,
   CodeSubmittableResult,
   BlueprintSubmittableResult,
+  InstantiateData,
 } from 'types';
-import { useCodeBundle } from 'ui/hooks/useCodeBundle';
-import { useWeight } from 'ui/hooks/useWeight';
-import { useMetadata } from 'ui/hooks/useMetadata';
-import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
-import { useFormField } from 'ui/hooks/useFormField';
-import { useToggle } from 'ui/hooks/useToggle';
+
 import { useStepper } from 'ui/hooks/useStepper';
-import { useAccountId } from 'ui/hooks/useAccountId';
-import { useBalance } from 'ui/hooks/useBalance';
-import { useArgValues } from 'ui/hooks/useArgValues';
 
-export const InstantiateContext = React.createContext({} as unknown as InstantiateProps);
+// type TxState = [
+//   SubmittableExtrinsic<'promise'> | null,
+//   OnInstantiateSuccess$Code | OnInstantiateSuccess$Hash,
+//   string | null
+// ];
 
-type TxState = [
-  SubmittableExtrinsic<'promise'> | null,
-  OnInstantiateSuccess$Code | OnInstantiateSuccess$Hash,
-  string | null
-];
-
-const NOOP = () => Promise.resolve();
+// const NOOP = () => Promise.resolve();
 
 export const CONTRACT_FILE = 0;
 export const DEPLOYMENT_INFO = 1;
@@ -52,143 +40,71 @@ export function isResultValid({
 }: CodeSubmittableResult<'promise'> | BlueprintSubmittableResult<'promise'>): boolean {
   return !!contract;
 }
+const initialFormState: InstantiateData = {
+  constructorIndex: 0,
+  argValues: undefined,
+  endowment: BN_THOUSAND,
+  name: '',
+  weight: BN_THOUSAND,
+};
+const initialState: InstantiateState = {
+  data: initialFormState,
+  currentStep: 0,
+};
+
+export const InstantiateContext = React.createContext(initialState);
 
 export function InstantiateContextProvider({
   children,
 }: React.PropsWithChildren<Partial<InstantiateProps>>) {
-  const history = useHistory();
-  const { codeHash } = useParams<{ codeHash: string }>();
-  const apiState = useApi();
-  const dbState = useDatabase();
+  // const history = useHistory();
+  // const { codeHash } = useParams<{ codeHash: string }>();
+  // const apiState = useApi();
+  // const dbState = useDatabase();
+  const [currentStep, stepForward, stepBackward] = useStepper();
+  // const [, , , setStep] = step;
 
-  const codeBundleQuery = useCodeBundle(codeHash);
+  const [data, setData] = useState<InstantiateData>(initialFormState);
+  // const [[tx, , txError], setTx] = useState<TxState>([null, NOOP, null]);
 
-  const codeBundle = codeBundleQuery.data;
-  const isLoading = useMemo(
-    () => !!codeHash && codeBundleQuery.isLoading,
-    [codeHash, codeBundleQuery.isLoading]
-  );
+  // const onSuccess = useCallback(
+  //   (contract: ContractPromise, _?: BlueprintPromise | undefined) => {
+  //     history.push(`/contract/${contract.address}`);
 
-  const step = useStepper();
-  const [, , , setStep] = step;
+  //     dbState.refreshUserData();
+  //   },
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  //   [dbState.refreshUserData]
+  // );
 
-  const isUsingStoredMetadata = useMemo(
-    (): boolean => !!codeBundle?.document,
-    [codeBundle?.document]
-  );
+  // function onFinalize() {
+  //   try {
+  //     const tx = createInstantiateTx(apiState.api, data);
 
-  const accountId = useAccountId();
+  //     const onInstantiate = (codeHash ? onInsantiateFromHash : onInstantiateFromCode)(
+  //       apiState,
+  //       dbState,
+  //       data
+  //     );
 
-  const name = useNonEmptyString();
-  const metadataFile = useState<FileState | undefined>();
+  //     setTx([tx, onInstantiate, null]);
+  //     setStep(FINALIZE);
+  //   } catch (e) {
+  //     setTx([null, NOOP, 'Error creating transaction']);
+  //   }
+  // }
 
-  const { onChange: setName } = name;
-  const [, setMetadataFile] = metadataFile;
+  // function onUnFinalize() {
+  //   setTx([null, NOOP, null]);
+  //   setStep(DEPLOYMENT_INFO);
+  // }
 
-  console.log(!codeBundle);
-
-  const metadata = useMetadata((codeBundle?.document?.abi as AnyJson) || null, {
-    isRequired: true,
-    isWasmRequired: !codeBundle,
-    onChange: setMetadataFile,
-  });
-
-  const constructorIndex = useFormField(0);
-  const endowment = useBalance(10000);
-  const weight = useWeight();
-  const isUsingSalt = useToggle();
-  const salt = useFormField<string>(randomAsHex(), value => {
-    if (!!value && isHex(value) && value.length === 66) {
-      return { isValid: true };
-    }
-
-    return { isValid: false, isError: true, message: 'Invalid hex string' };
-  });
-
-  const deployConstructor = useMemo(
-    (): AbiConstructor | null =>
-      isNumber(constructorIndex.value)
-        ? metadata.value?.constructors[constructorIndex.value] || null
-        : null,
-    [metadata.value, constructorIndex.value]
-  );
-  const argValues = useArgValues(deployConstructor?.args || []);
-
-  const onSuccess = useCallback(
-    (contract: ContractPromise, _?: BlueprintPromise | undefined) => {
-      history.push(`/contract/${contract.address}`);
-
-      dbState.refreshUserData();
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dbState.refreshUserData]
-  );
-
-  const [[tx, onInstantiate, txError], setTx] = useState<TxState>([null, NOOP, null]);
-
-  useEffect((): void => {
-    if (metadata.value?.info.contract.name && (!name.value || name.value === '')) {
-      setName(metadata.value?.info.contract.name.toString());
-    }
-  }, [metadata.value, name.value, setName]);
-
-  useEffect((): void => {
-    if (codeHash && !codeBundleQuery.isValid) {
-      history.replace('/instantiate/hash');
-    }
-    //
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [codeHash, codeBundleQuery.isValid]);
-
-  const state: InstantiateState = {
-    accountId,
-    codeHash,
-    constructorIndex,
-    deployConstructor,
-    argValues,
-    endowment,
-    isLoading,
-    isUsingSalt,
-    isUsingStoredMetadata,
-    metadata,
-    metadataFile,
-    onError: NOOP,
-    onSuccess,
-    name,
-    salt,
-    step,
-    weight,
-  } as unknown as InstantiateState;
-
-  function onFinalize() {
-    try {
-      const tx = createInstantiateTx(apiState.api, state);
-
-      const onInstantiate = (codeHash ? onInsantiateFromHash : onInstantiateFromCode)(
-        apiState,
-        dbState,
-        state
-      );
-
-      setTx([tx, onInstantiate, null]);
-      setStep(FINALIZE);
-    } catch (e) {
-      setTx([null, NOOP, 'Error creating transaction']);
-    }
-  }
-
-  function onUnFinalize() {
-    setTx([null, NOOP, null]);
-    setStep(DEPLOYMENT_INFO);
-  }
-
-  const value = {
-    ...state,
-    onFinalize,
-    onUnFinalize,
-    onInstantiate,
-    tx,
-    txError,
+  const value: InstantiateState = {
+    data,
+    setData,
+    currentStep,
+    stepForward,
+    stepBackward,
   };
 
   return <InstantiateContext.Provider value={value}>{children}</InstantiateContext.Provider>;

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -61,7 +61,7 @@ export function InstantiateContextProvider({
   const apiState = useApi();
   const dbState = useDatabase();
 
-  const codeBundleQuery = useCodeBundle(codeHash || null);
+  const codeBundleQuery = useCodeBundle(codeHash);
 
   const codeBundle = codeBundleQuery.data;
   const isLoading = useMemo(

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -31,10 +31,6 @@ import { useStepper } from 'ui/hooks/useStepper';
 
 // const NOOP = () => Promise.resolve();
 
-export const CONTRACT_FILE = 0;
-export const DEPLOYMENT_INFO = 1;
-export const FINALIZE = 2;
-
 export function isResultValid({
   contract,
 }: CodeSubmittableResult<'promise'> | BlueprintSubmittableResult<'promise'>): boolean {
@@ -42,14 +38,13 @@ export function isResultValid({
 }
 const initialFormState: InstantiateData = {
   constructorIndex: 0,
-  argValues: undefined,
   endowment: BN_THOUSAND,
   name: '',
   weight: BN_THOUSAND,
 };
 const initialState: InstantiateState = {
   data: initialFormState,
-  currentStep: 0,
+  currentStep: 1,
 };
 
 export const InstantiateContext = React.createContext(initialState);
@@ -61,7 +56,7 @@ export function InstantiateContextProvider({
   // const { codeHash } = useParams<{ codeHash: string }>();
   // const apiState = useApi();
   // const dbState = useDatabase();
-  const [currentStep, stepForward, stepBackward] = useStepper();
+  const [currentStep, stepForward, stepBackward] = useStepper(initialState.currentStep);
   // const [, , , setStep] = step;
 
   const [data, setData] = useState<InstantiateData>(initialFormState);

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -61,9 +61,9 @@ export function InstantiateContextProvider({
   const apiState = useApi();
   const dbState = useDatabase();
 
-  const codeBundleQuery = useCodeBundle(codeHash || undefined);
+  const codeBundleQuery = useCodeBundle(codeHash || null);
 
-  const [isOnChain, codeBundle] = codeBundleQuery.data || [false, null];
+  const codeBundle = codeBundleQuery.data;
   const isLoading = useMemo(
     () => !!codeHash && codeBundleQuery.isLoading,
     [codeHash, codeBundleQuery.isLoading]
@@ -72,7 +72,10 @@ export function InstantiateContextProvider({
   const step = useStepper();
   const [, , , setStep] = step;
 
-  const isUsingStoredMetadata = useMemo((): boolean => !!codeBundle?.abi, [codeBundle?.abi]);
+  const isUsingStoredMetadata = useMemo(
+    (): boolean => !!codeBundle?.document,
+    [codeBundle?.document]
+  );
 
   const accountId = useAccountId();
 
@@ -84,9 +87,9 @@ export function InstantiateContextProvider({
 
   console.log(!codeBundle);
 
-  const metadata = useMetadata((codeBundle?.abi as AnyJson) || null, {
+  const metadata = useMetadata((codeBundle?.document?.abi as AnyJson) || null, {
     isRequired: true,
-    isWasmRequired: !isOnChain,
+    isWasmRequired: !codeBundle,
     onChange: setMetadataFile,
   });
 

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -56,7 +56,7 @@ export function InstantiateContextProvider({
   const dbState = useDatabase();
   const apiState = useApi();
   const NOOP = () => Promise.resolve();
-  const { codeHash } = useParams<{ codeHash: string }>();
+  const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
   const [currentStep, stepForward, stepBackward, setStep] = useStepper(initialState.currentStep);
 
   const [data, setData] = useState<InstantiateData>(initialState.data);
@@ -77,7 +77,7 @@ export function InstantiateContextProvider({
     try {
       const tx = createInstantiateTx(apiState.api, newData);
 
-      const onInstantiate = (codeHash ? onInsantiateFromHash : onInstantiateFromCode)(
+      const onInstantiate = (codeHashUrlParam ? onInsantiateFromHash : onInstantiateFromCode)(
         apiState,
         dbState,
         data,

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -10,6 +10,6 @@ export * from './useMyContracts';
 export * from './useStatistics';
 export * from './useToggleContractStar';
 export * from './useTopContracts';
-export * from './useQuery';
+export * from './useDbQuery';
 export * from './useWeight';
 export * from './useBlockTime';

--- a/src/ui/hooks/useAccountId.ts
+++ b/src/ui/hooks/useAccountId.ts
@@ -6,12 +6,12 @@ import { useFormField } from './useFormField';
 import { useApi } from 'ui/contexts/ApiContext';
 import type { OrFalsy, UseFormField, Validation } from 'types';
 
-export function useAccountId(initialValue: string | null = null): UseFormField<string | null> {
+export function useAccountId(initialValue = ''): UseFormField<string> {
   const { keyring } = useApi();
 
   const validate = useCallback(
     (value: OrFalsy<string>): Validation => {
-      if (!value || !keyring?.getAccount(value)) {
+      if (!value?.trim() || !keyring?.getAccount(value)) {
         return { isValid: false, message: 'Specified account does not exist' };
       }
 
@@ -20,8 +20,5 @@ export function useAccountId(initialValue: string | null = null): UseFormField<s
     [keyring]
   );
 
-  return useFormField<string | null>(
-    initialValue || keyring?.getAccounts()[0].address || null,
-    validate
-  );
+  return useFormField<string>(initialValue || keyring?.getAccounts()[0].address || '', validate);
 }

--- a/src/ui/hooks/useArgValues.ts
+++ b/src/ui/hooks/useArgValues.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useApi } from 'ui/contexts/ApiContext';
 import { AbiParam, ApiPromise, Keyring, SetState } from 'types';
 import { getInitValue } from 'ui/util';
@@ -18,18 +18,16 @@ function fromArgs(api: ApiPromise, keyring: Keyring, args: AbiParam[]): ArgValue
   return result;
 }
 
-export function useArgValues(args: AbiParam[]): [ArgValues, SetState<ArgValues>] {
+export function useArgValues(
+  args: AbiParam[]
+): [ArgValues, SetState<ArgValues>, SetState<AbiParam[]>] {
   const { api, keyring } = useApi();
-
+  const [params, setParams] = useState(args);
   const [value, setValue] = useState<ArgValues>(fromArgs(api, keyring, args));
-  const argsRef = useRef(args);
 
   useEffect((): void => {
-    if (argsRef.current !== args && !(argsRef.current.length === 0 && args.length === 0)) {
-      setValue(fromArgs(api, keyring, args));
-      argsRef.current = args;
-    }
-  }, [args, api, keyring]);
+    setValue(fromArgs(api, keyring, params));
+  }, [params, api, keyring]);
 
-  return [value, setValue];
+  return [value, setValue, setParams];
 }

--- a/src/ui/hooks/useAvailableCodeBundles.ts
+++ b/src/ui/hooks/useAvailableCodeBundles.ts
@@ -7,7 +7,7 @@ import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';
 import { findOwnedCodeBundles, findTopCodeBundles } from 'db/queries';
 
-import type { CodeBundleDocument, UseQuery } from 'types';
+import type { CodeBundleDocument, DbQuery } from 'types';
 
 type ReturnType = [CodeBundleDocument[], CodeBundleDocument[]];
 
@@ -15,7 +15,7 @@ function byDate(a: CodeBundleDocument, b: CodeBundleDocument): number {
   return moment(b.date).valueOf() - moment(a.date).valueOf();
 }
 
-export function useAvailableCodeBundles(limit = 1): UseQuery<ReturnType> {
+export function useAvailableCodeBundles(limit = 1): DbQuery<ReturnType> {
   const { db, identity } = useDatabase();
 
   const query = useCallback(async (): Promise<ReturnType> => {

--- a/src/ui/hooks/useAvailableCodeBundles.ts
+++ b/src/ui/hooks/useAvailableCodeBundles.ts
@@ -4,7 +4,7 @@
 import moment from 'moment';
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findOwnedCodeBundles, findTopCodeBundles } from 'db/queries';
 
 import type { CodeBundleDocument, UseQuery } from 'types';
@@ -26,5 +26,5 @@ export function useAvailableCodeBundles(limit = 1): UseQuery<ReturnType> {
     return [owned, popular];
   }, [db, identity, limit]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useBalance.ts
+++ b/src/ui/hooks/useBalance.ts
@@ -79,7 +79,7 @@ export function useBalance(
     []
   );
 
-  const balance = useFormField<BN | null | undefined>(
+  const balance = useFormField<BN>(
     isBn(initialValue) ? toSats(api, initialValue) : toBalance(api, initialValue),
     value => validate(value, { isZeroable, maxValue })
   );

--- a/src/ui/hooks/useCodeBundle.ts
+++ b/src/ui/hooks/useCodeBundle.ts
@@ -14,12 +14,12 @@ function isValidHash(input: OrFalsy<string>): boolean {
   return !!input && codeHashRegex.test(input);
 }
 
-export function useCodeBundle(codeHash: string | null): DbQuery<CodeBundle> {
+export function useCodeBundle(codeHash: string): DbQuery<CodeBundle> {
   const { api, blockZeroHash } = useApi();
   const { db } = useDatabase();
 
   const query = useCallback(async (): Promise<CodeBundle> => {
-    if (isValidHash(codeHash) && typeof codeHash === 'string') {
+    if (isValidHash(codeHash)) {
       const isOnChain = !(await api.query.contracts.codeStorage(codeHash)).isEmpty;
       const document = await findCodeBundleByHash(db, { blockZeroHash, codeHash });
       return { document, isOnChain };

--- a/src/ui/hooks/useCodeBundle.ts
+++ b/src/ui/hooks/useCodeBundle.ts
@@ -4,7 +4,7 @@
 import { useCallback } from 'react';
 import { useApi } from '../contexts/ApiContext';
 import { useDatabase } from '../contexts/DatabaseContext';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findCodeBundleByHash } from 'db/queries';
 
 import { Abi } from 'types';
@@ -34,5 +34,5 @@ export function useCodeBundle(codeHash?: string | null): UseQuery<ReturnType> {
     return [true, document, document ? new Abi(document.abi as AnyJson) : null];
   }, [api.query.contracts, blockZeroHash, codeHash, db]);
 
-  return useQuery(query, result => !!result && result[0]);
+  return useDbQuery(query, result => !!result && result[0]);
 }

--- a/src/ui/hooks/useCodeBundleSearch.ts
+++ b/src/ui/hooks/useCodeBundleSearch.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { searchForCodeBundle } from 'db';
 import type { CodeBundleDocument } from 'types';
 import { useDatabase } from 'ui/contexts/DatabaseContext';
@@ -14,5 +14,5 @@ export function useCodeBundleSearch(fragment: string) {
     return searchForCodeBundle(db, fragment);
   }, [db, fragment]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useContract.ts
+++ b/src/ui/hooks/useContract.ts
@@ -6,7 +6,7 @@ import { useDatabase } from '../contexts/DatabaseContext';
 import { useDbQuery } from './useDbQuery';
 import { findContractByAddress } from 'db/queries';
 
-import { Abi, AnyJson, ContractDocument, ContractPromise as Contract, DbQuery } from 'types';
+import { Abi, ContractDocument, ContractPromise as Contract, DbQuery } from 'types';
 import { useApi } from 'ui/contexts';
 
 type ReturnType = [Contract | null, ContractDocument | null];
@@ -19,7 +19,7 @@ export function useContract(address: string): DbQuery<ReturnType> {
     const document = await findContractByAddress(db, address);
 
     return api && document
-      ? [new Contract(api, new Abi(document.abi as AnyJson), address), document]
+      ? [new Contract(api, new Abi(document.abi), address), document]
       : [null, null];
   }, [db, address, api]);
 

--- a/src/ui/hooks/useContract.ts
+++ b/src/ui/hooks/useContract.ts
@@ -6,12 +6,12 @@ import { useDatabase } from '../contexts/DatabaseContext';
 import { useDbQuery } from './useDbQuery';
 import { findContractByAddress } from 'db/queries';
 
-import { Abi, AnyJson, ContractDocument, ContractPromise as Contract, UseQuery } from 'types';
+import { Abi, AnyJson, ContractDocument, ContractPromise as Contract, DbQuery } from 'types';
 import { useApi } from 'ui/contexts';
 
 type ReturnType = [Contract | null, ContractDocument | null];
 
-export function useContract(address: string): UseQuery<ReturnType> {
+export function useContract(address: string): DbQuery<ReturnType> {
   const { api } = useApi();
   const { db } = useDatabase();
 

--- a/src/ui/hooks/useContract.ts
+++ b/src/ui/hooks/useContract.ts
@@ -3,7 +3,7 @@
 
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts/DatabaseContext';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findContractByAddress } from 'db/queries';
 
 import { Abi, AnyJson, ContractDocument, ContractPromise as Contract, UseQuery } from 'types';
@@ -23,5 +23,5 @@ export function useContract(address: string): UseQuery<ReturnType> {
       : [null, null];
   }, [db, address, api]);
 
-  return useQuery(query, result => !!result && !!result[0]);
+  return useDbQuery(query, result => !!result && !!result[0]);
 }

--- a/src/ui/hooks/useDbQuery.ts
+++ b/src/ui/hooks/useDbQuery.ts
@@ -27,7 +27,7 @@ const initialState = {
   updated: 0,
 };
 
-export function useQuery<T>(
+export function useDbQuery<T>(
   query: () => Promise<T | null>,
   validate: ValidateFn<T> = value => !!value
 ): UseQuery<T> {

--- a/src/ui/hooks/useDbQuery.ts
+++ b/src/ui/hooks/useDbQuery.ts
@@ -1,23 +1,13 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDatabase } from '../contexts/DatabaseContext';
-import type { VoidFn } from 'types';
+import type { DbQuery } from 'types';
 
 type ValidateFn<T> = (_?: T | null) => boolean;
 
-interface State<T> {
-  data: T | null;
-  error: React.ReactNode | null;
-  isLoading: boolean;
-  isValid: boolean;
-  updated: number;
-}
-
-interface UseQuery<T> extends State<T> {
-  refresh: VoidFn;
-}
+type State<T> = Omit<DbQuery<T>, 'refresh'>;
 
 const initialState = {
   data: null,
@@ -30,7 +20,7 @@ const initialState = {
 export function useDbQuery<T>(
   query: () => Promise<T | null>,
   validate: ValidateFn<T> = value => !!value
-): UseQuery<T> {
+): DbQuery<T> {
   const { isDbReady } = useDatabase();
   const [state, setState] = useState<State<T>>(initialState);
 

--- a/src/ui/hooks/useMetadata.ts
+++ b/src/ui/hooks/useMetadata.ts
@@ -60,8 +60,8 @@ function deriveFromJson(
 
     return {
       source,
-      name: null,
-      value: null,
+      name: '',
+      value,
       isSupplied: true,
       ...validate(value, options),
     };
@@ -72,9 +72,8 @@ const EMPTY: MetadataState = {
   isError: false,
   isSupplied: false,
   isValid: false,
-  name: null,
+  name: '',
   source: null,
-  value: null,
   message: null,
 };
 

--- a/src/ui/hooks/useMyCodeBundles.ts
+++ b/src/ui/hooks/useMyCodeBundles.ts
@@ -3,7 +3,7 @@
 
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findMyCodeBundles } from 'db/queries';
 
 import type { MyCodeBundles, UseQuery } from 'types';
@@ -15,5 +15,5 @@ export function useMyCodeBundles(): UseQuery<MyCodeBundles> {
     return findMyCodeBundles(db, identity);
   }, [db, identity]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useMyCodeBundles.ts
+++ b/src/ui/hooks/useMyCodeBundles.ts
@@ -6,9 +6,9 @@ import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';
 import { findMyCodeBundles } from 'db/queries';
 
-import type { MyCodeBundles, UseQuery } from 'types';
+import type { MyCodeBundles, DbQuery } from 'types';
 
-export function useMyCodeBundles(): UseQuery<MyCodeBundles> {
+export function useMyCodeBundles(): DbQuery<MyCodeBundles> {
   const { db, identity } = useDatabase();
 
   const query = useCallback((): Promise<MyCodeBundles | null> => {

--- a/src/ui/hooks/useMyContracts.ts
+++ b/src/ui/hooks/useMyContracts.ts
@@ -6,9 +6,9 @@ import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';
 import { findMyContracts } from 'db/queries';
 
-import type { MyContracts, UseQuery } from 'types';
+import type { MyContracts, DbQuery } from 'types';
 
-export function useMyContracts(): UseQuery<MyContracts> {
+export function useMyContracts(): DbQuery<MyContracts> {
   const { db, identity } = useDatabase();
 
   const query = useCallback((): Promise<MyContracts | null> => {

--- a/src/ui/hooks/useMyContracts.ts
+++ b/src/ui/hooks/useMyContracts.ts
@@ -3,7 +3,7 @@
 
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findMyContracts } from 'db/queries';
 
 import type { MyContracts, UseQuery } from 'types';
@@ -15,5 +15,5 @@ export function useMyContracts(): UseQuery<MyContracts> {
     return findMyContracts(db, identity);
   }, [db, identity]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useQueueTx.ts
+++ b/src/ui/hooks/useQueueTx.ts
@@ -40,8 +40,7 @@ export function useQueueTx(
       setTxId(newId);
       txIdRef.current = newId;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [accountId, extrinsic, isValid, onError, onSuccess, queue, txId]);
 
   return [onSubmit, onCancel, !isNull(txId), isProcessing];
 }

--- a/src/ui/hooks/useStatistics.ts
+++ b/src/ui/hooks/useStatistics.ts
@@ -6,9 +6,9 @@ import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';
 import { getStatistics } from 'db/queries';
 
-import type { DbStatistics, UseQuery } from 'types';
+import type { DbStatistics, DbQuery } from 'types';
 
-export function useStatistics(): UseQuery<DbStatistics> {
+export function useStatistics(): DbQuery<DbStatistics> {
   const { db } = useDatabase();
 
   const query = useCallback((): Promise<DbStatistics | null> => {

--- a/src/ui/hooks/useStatistics.ts
+++ b/src/ui/hooks/useStatistics.ts
@@ -3,7 +3,7 @@
 
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { getStatistics } from 'db/queries';
 
 import type { DbStatistics, UseQuery } from 'types';
@@ -15,5 +15,5 @@ export function useStatistics(): UseQuery<DbStatistics> {
     return getStatistics(db);
   }, [db]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useStepper.ts
+++ b/src/ui/hooks/useStepper.ts
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react';
 
 import type { UseStepper } from 'types';
 
-export function useStepper(initialValue = 0, maxValue = 2): UseStepper {
+export function useStepper(initialValue = 0, maxValue = 3): UseStepper {
   const [value, setValue] = useState(Math.min(initialValue, maxValue));
 
   const increment = useCallback((): void => {

--- a/src/ui/hooks/useTopContracts.ts
+++ b/src/ui/hooks/useTopContracts.ts
@@ -3,7 +3,7 @@
 
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
-import { useQuery } from './useQuery';
+import { useDbQuery } from './useDbQuery';
 import { findTopContracts } from 'db/queries';
 
 import type { ContractDocument, UseQuery } from 'types';
@@ -15,5 +15,5 @@ export function useTopContracts(): UseQuery<ContractDocument[]> {
     return findTopContracts(db);
   }, [db]);
 
-  return useQuery(query);
+  return useDbQuery(query);
 }

--- a/src/ui/hooks/useTopContracts.ts
+++ b/src/ui/hooks/useTopContracts.ts
@@ -6,9 +6,9 @@ import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';
 import { findTopContracts } from 'db/queries';
 
-import type { ContractDocument, UseQuery } from 'types';
+import type { ContractDocument, DbQuery } from 'types';
 
-export function useTopContracts(): UseQuery<ContractDocument[]> {
+export function useTopContracts(): DbQuery<ContractDocument[]> {
   const { db } = useDatabase();
 
   const query = useCallback((): Promise<ContractDocument[] | null> => {

--- a/src/ui/pages/Instantiate.tsx
+++ b/src/ui/pages/Instantiate.tsx
@@ -4,50 +4,45 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Wizard } from '../components/instantiate';
-import { Loader } from '../components/common/Loader';
-import { useInstantiate } from 'ui/contexts';
 
 export function Instantiate() {
   const { pathname } = useLocation();
-  const { isLoading } = useInstantiate();
 
   const isFromHash = /instantiate\/hash/.test(pathname);
 
   return (
-    <Loader isLoading={isLoading}>
-      <div className="w-full max-w-6xl overflow-y-auto px-5 py-3 m-2">
-        <div className="grid md:grid-cols-12 gap-5">
-          <div className="md:col-span-9 py-3 px-4">
-            <div className="space-y-1 border-b pb-6 dark:border-gray-800 border-gray-200">
-              <h1 className="text-2.5xl dark:text-white text-gray-700">
-                {isFromHash
-                  ? 'Instantiate Contract from Code Hash'
-                  : 'Upload and Instantiate Contract'}
-              </h1>
-              <p className="dark:text-gray-400 text-gray-500 text-sm">
-                {isFromHash ? (
-                  <>
-                    You can upload and instantate new contract code{' '}
-                    <Link to="/instantiate/new" className="text-blue-500">
-                      here
-                    </Link>
-                    .
-                  </>
-                ) : (
-                  <>
-                    You can instantiate a new contract from an existing code bundle{' '}
-                    <Link to="/instantiate/hash" className="text-blue-500">
-                      here
-                    </Link>
-                    .
-                  </>
-                )}
-              </p>
-            </div>
+    <div className="w-full max-w-6xl overflow-y-auto px-5 py-3 m-2">
+      <div className="grid md:grid-cols-12 gap-5">
+        <div className="md:col-span-9 py-3 px-4">
+          <div className="space-y-1 border-b pb-6 dark:border-gray-800 border-gray-200">
+            <h1 className="text-2.5xl dark:text-white text-gray-700">
+              {isFromHash
+                ? 'Instantiate Contract from Code Hash'
+                : 'Upload and Instantiate Contract'}
+            </h1>
+            <p className="dark:text-gray-400 text-gray-500 text-sm">
+              {isFromHash ? (
+                <>
+                  You can upload and instantate new contract code{' '}
+                  <Link to="/instantiate/new" className="text-blue-500">
+                    here
+                  </Link>
+                  .
+                </>
+              ) : (
+                <>
+                  You can instantiate a new contract from an existing code bundle{' '}
+                  <Link to="/instantiate/hash" className="text-blue-500">
+                    here
+                  </Link>
+                  .
+                </>
+              )}
+            </p>
           </div>
         </div>
-        <Wizard />
       </div>
-    </Loader>
+      <Wizard />
+    </div>
   );
 }


### PR DESCRIPTION
store in context only what is needed for instantiation 
store form state in step components
simpler interfaces for some hooks 
no more typecasting to `unknown` 

to do: step components have become quite large, they need to be split 
