### PR TITLE
IndexedDB name refactoring

### DIFF
--- a/__test-utils__/mocks/db.ts
+++ b/__test-utils__/mocks/db.ts
@@ -65,14 +65,12 @@ export function getMockDbUsers(count: number): TestUser[] {
 export function getMockCodeBundles(): CodeBundleDocument[] {
   const codeBundles: CodeBundleDocument[] = [];
 
-  const blockZeroHashes = [randomHash(), randomHash()];
   const genesisHash = randomHash();
 
   MOCK_CONTRACT_DATA.forEach(([name, , tags]) => {
     const abi = (contractFiles as Record<string, AnyJson>)[name.toLowerCase()];
 
     codeBundles.push({
-      blockZeroHash: blockZeroHashes[Math.round(Math.random())],
       codeHash: randomHash(),
       creator: getKeyringPairRandom().address,
       genesisHash,
@@ -92,7 +90,7 @@ export function getMockCodeBundles(): CodeBundleDocument[] {
 export function getMockContracts(codeBundles: CodeBundleDocument[]): ContractDocument[] {
   const contracts: ContractDocument[] = [];
 
-  const { blockZeroHash, creator, genesisHash } = codeBundles[0];
+  const { creator, genesisHash } = codeBundles[0];
 
   // Original instantiation and 0-2 reinstantiations
   MOCK_CONTRACT_DATA.forEach(([name, , tags], index) => {
@@ -100,7 +98,6 @@ export function getMockContracts(codeBundles: CodeBundleDocument[]): ContractDoc
 
     contracts.push({
       address: faker.random.alphaNumeric(62),
-      blockZeroHash,
       creator,
       genesisHash,
       codeHash: codeBundles[index].codeHash,

--- a/__tests__/db/queries/index.test.ts
+++ b/__tests__/db/queries/index.test.ts
@@ -95,9 +95,9 @@ describe('DB Queries', (): void => {
   });
 
   it('findCodeBundleByHash', async () => {
-    const { codeHash, blockZeroHash } = testCodeBundles[0];
+    const { codeHash } = testCodeBundles[0];
 
-    const result = await q.findCodeBundleByHash(db, { codeHash, blockZeroHash });
+    const result = await q.findCodeBundleByHash(db, codeHash);
 
     expect(result).toBeTruthy();
     expect(result).toMatchObject({ ...testCodeBundles[0], instances: 1 });

--- a/src/api/instantiate/instantiate.ts
+++ b/src/api/instantiate/instantiate.ts
@@ -13,7 +13,7 @@ import type {
 import { createContract } from 'db';
 
 export function onInsantiateFromHash(
-  { api, blockZeroHash }: ApiState,
+  { api }: ApiState,
   { db, identity }: DbState,
   { accountId, codeHash, name }: InstantiateData,
   onSuccess: InstantiateState['onSuccess']
@@ -28,7 +28,6 @@ export function onInsantiateFromHash(
         abi: contract.abi.json,
         address: contract.address.toString(),
         creator: accountId,
-        blockZeroHash: blockZeroHash || undefined,
         codeHash,
         genesisHash: api?.genesisHash.toString(),
         name: name,
@@ -41,7 +40,7 @@ export function onInsantiateFromHash(
 }
 
 export function onInstantiateFromCode(
-  { api, blockZeroHash }: ApiState,
+  { api }: ApiState,
   { db, identity }: DbState,
   { accountId, name }: InstantiateData,
   onSuccess: InstantiateState['onSuccess']
@@ -58,7 +57,6 @@ export function onInstantiateFromCode(
         await createContract(db, identity, {
           abi: contract.abi.json,
           address: contract.address.toString(),
-          blockZeroHash: blockZeroHash || undefined,
           creator: accountId,
           codeHash: blueprint?.codeHash.toHex() || contract.abi.info.source.wasmHash.toHex(),
           genesisHash: api?.genesisHash.toString(),

--- a/src/api/util/blockTime.ts
+++ b/src/api/util/blockTime.ts
@@ -1,0 +1,25 @@
+// Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import BN from 'bn.js';
+import { BN_THOUSAND, BN_TWO } from '@polkadot/util';
+import { ApiPromise, OrFalsy } from 'types';
+
+const DEFAULT_TIME = new BN(6_000);
+
+const THRESHOLD = BN_THOUSAND.div(BN_TWO);
+
+export function blockTimeMs(a: OrFalsy<ApiPromise>): BN {
+  return (a?.consts.babe?.expectedBlockTime || // Babe
+    // POW, eg. Kulupu
+    a?.consts.difficulty?.targetBlockTime ||
+    // Check against threshold to determine value validity
+    (a?.consts.timestamp?.minimumPeriod.gte(THRESHOLD)
+      ? // Default minimum period config
+        a.consts.timestamp.minimumPeriod.mul(BN_TWO)
+      : a?.query.parachainSystem
+      ? // default guess for a parachain
+        DEFAULT_TIME.mul(BN_TWO)
+      : // default guess for others
+        DEFAULT_TIME)) as BN;
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,7 +7,7 @@ export const LOCAL_NODE = 'ws://127.0.0.1:9944'; //wss://canvas-rpc.parity.io
 export const DEFAULT_DECIMALS = 12;
 
 export const NULL_CHAIN_PROPERTIES = {
-  blockZeroHash: null,
+  blockOneHash: null,
   systemName: null,
   systemVersion: null,
   tokenDecimals: DEFAULT_DECIMALS,

--- a/src/db/queries/codeBundle.ts
+++ b/src/db/queries/codeBundle.ts
@@ -6,7 +6,7 @@ import moment from 'moment';
 import { getNewCodeBundleId, publicKeyHex } from '../util';
 import { findUser } from './user';
 import { getCodeBundleCollection, getContractCollection, pushToRemote } from './util';
-import type { CodeBundleDocument, CodeBundleQuery, MyCodeBundles } from 'types';
+import type { CodeBundleDocument, MyCodeBundles } from 'types';
 
 export async function findTopCodeBundles(
   db: Database,
@@ -97,14 +97,9 @@ export async function findMyCodeBundles(
 
 export async function findCodeBundleByHash(
   db: Database,
-  { codeHash, blockZeroHash }: CodeBundleQuery
+  codeHash: string
 ): Promise<CodeBundleDocument | null> {
-  return (
-    (await getCodeBundleCollection(db).findOne({
-      blockZeroHash: blockZeroHash || undefined,
-      codeHash,
-    })) || null
-  );
+  return (await getCodeBundleCollection(db).findOne({ codeHash })) || null;
 }
 
 export async function findCodeBundleById(
@@ -140,7 +135,6 @@ export async function createCodeBundle(
   owner: PrivateKey | null,
   {
     abi,
-    blockZeroHash,
     codeHash,
     creator,
     genesisHash,
@@ -167,7 +161,6 @@ export async function createCodeBundle(
 
     const newCode = getCodeBundleCollection(db).create({
       abi,
-      blockZeroHash,
       codeHash,
       creator,
       genesisHash,

--- a/src/db/queries/contract.ts
+++ b/src/db/queries/contract.ts
@@ -60,7 +60,6 @@ export async function createContract(
   {
     abi,
     address,
-    blockZeroHash,
     codeHash,
     creator,
     date = moment.utc().format(),
@@ -71,7 +70,7 @@ export async function createContract(
   savePair = true
 ): Promise<ContractDocument> {
   try {
-    if (!abi || !address || !codeHash || !creator || !name || !genesisHash || !blockZeroHash) {
+    if (!abi || !address || !codeHash || !creator || !name || !genesisHash) {
       return Promise.reject(new Error('Missing required fields'));
     }
 
@@ -79,12 +78,11 @@ export async function createContract(
       return Promise.reject(new Error('Contract already exists'));
     }
 
-    const exists = await getCodeBundleCollection(db).findOne({ blockZeroHash, codeHash });
+    const exists = await getCodeBundleCollection(db).findOne({ codeHash });
 
     if (!exists) {
       await createCodeBundle(db, owner, {
         abi,
-        blockZeroHash,
         codeHash,
         creator,
         genesisHash,
@@ -103,8 +101,7 @@ export async function createContract(
     const newContract = getContractCollection(db).create({
       abi,
       address,
-      blockZeroHash,
-      codeHash: codeHash,
+      codeHash,
       creator,
       genesisHash,
       name,

--- a/src/db/queries/index.ts
+++ b/src/db/queries/index.ts
@@ -1,40 +1,6 @@
 // Copyright 2021 @paritytech/substrate-contracts-explorer authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Database } from '@textile/threaddb';
-import { getCodeBundleCollection, getContractCollection } from './util';
-
-export async function checkForExpiredDocuments(
-  db: Database,
-  blockZeroHash: string
-): Promise<boolean> {
-  const expiredCodes = await getCodeBundleCollection(db)
-    .find({ blockZeroHash: { $ne: blockZeroHash } })
-    .toArray();
-  const expiredContracts = await getContractCollection(db)
-    .find({ blockZeroHash: { $ne: blockZeroHash } })
-    .toArray();
-
-  return expiredCodes.length > 0 || expiredContracts.length > 0;
-}
-
-export async function dropExpiredDocuments(db: Database, blockZeroHash: string): Promise<void> {
-  await Promise.all(
-    (
-      await getCodeBundleCollection(db)
-        .find({ blockZeroHash: { $ne: blockZeroHash } })
-        .toArray()
-    ).map(code => code.remove())
-  );
-  await Promise.all(
-    (
-      await getContractCollection(db)
-        .find({ blockZeroHash: { $ne: blockZeroHash } })
-        .toArray()
-    ).map(contract => contract.remove())
-  );
-}
-
 export * from './codeBundle';
 export * from './contract';
 export * from './derive';

--- a/src/db/schemas/codeBundle.schema.json
+++ b/src/db/schemas/codeBundle.schema.json
@@ -21,10 +21,6 @@
       "description": "The Polkadot address that uploaded this code bundle",
       "type": "string"
     },
-    "blockZeroHash": {
-      "description": "The identifying block hash for the code bundle's chain (for distinguishing development/local node instances)",
-      "type": "string"
-    },
     "codeHash": {
       "description": "The code bundle's unique hash",
       "type": "string"

--- a/src/db/schemas/contract.schema.json
+++ b/src/db/schemas/contract.schema.json
@@ -17,10 +17,6 @@
       "description": "The Polkadot address that instantiated this contract",
       "type": "string"
     },
-    "blockZeroHash": {
-      "description": "The identifying block hash for the contract's chain (for distinguishing development/local node instances)",
-      "type": "string"
-    },
     "address": {
       "description": "The contract's instantiation address",
       "type": "string"

--- a/src/db/util/init.ts
+++ b/src/db/util/init.ts
@@ -12,40 +12,65 @@ import { getStoredPrivateKey } from './identity';
 import type { UserDocument } from 'types';
 
 const DB_VERSION_KEY = 'substrate-contracts-explorer:db-version';
+const LOCAL_NODE_DB_NAME = 'substrate-contracts-explorer:local-db-name';
 
 function isLocalNode(rpcUrl: string): boolean {
-  return !rpcUrl.includes('127.0.0.1');
+  return rpcUrl.includes('127.0.0.1');
+}
+
+function purgeOutdatedDBs(blockOneHash: string) {
+  // TODO: Investigate use of indexedDB.databases() - not present in Firefox?
+  const oldLocalDbName = window.localStorage.getItem(LOCAL_NODE_DB_NAME);
+
+  if (oldLocalDbName) {
+    const [url, hash] = oldLocalDbName.split('_');
+
+    if (isLocalNode(url) && hash !== blockOneHash) {
+      console.log(`Deleting database ${oldLocalDbName}...`);
+      indexedDB.deleteDatabase(oldLocalDbName);
+    }
+  }
 }
 
 export async function init(
   rpcUrl: string,
+  blockOneHash: string,
   isRemote = false
 ): Promise<[DB, UserDocument | null, PrivateKey | null]> {
-  const db = await initDb(rpcUrl);
+  const name = `${rpcUrl}__${blockOneHash}`;
+  console.log(name);
+  const db = await initDb(name);
   const [user, identity] = await initIdentity(db);
 
   if (isRemote && identity && !isLocalNode(rpcUrl)) {
     await initRemote(db, identity, rpcUrl);
   }
 
+  if (isLocalNode(rpcUrl)) {
+    purgeOutdatedDBs(blockOneHash);
+
+    window.localStorage.setItem(LOCAL_NODE_DB_NAME, name);
+  }
+
   return [db, user, identity];
 }
 
-export async function initDb(rpcUrl: string): Promise<DB> {
+export async function initDb(name: string): Promise<DB> {
+  window.localStorage.removeItem(DB_VERSION_KEY);
+
   let db: DB;
-  let version = parseInt(window.localStorage.getItem(DB_VERSION_KEY) || '1', 10) || 1;
+  let version = 0;
   let isReady = false;
 
   while (!isReady && version <= 999) {
     try {
       db = await new DB(
-        rpcUrl,
+        name,
         { name: 'User', schema: user },
         { name: 'Contract', schema: contract },
         { name: 'CodeBundle', schema: codeBundle }
       ).open(version);
 
-      window.localStorage.setItem(DB_VERSION_KEY, version.toString());
       isReady = true;
       return db;
     } catch (e) {

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -23,7 +23,6 @@ export interface UserDocument extends Document {
 
 export interface CodeBundleDocument extends Document {
   abi?: AnyJson;
-  blockZeroHash?: string;
   codeHash: string;
   creator: string;
   date: string;
@@ -39,7 +38,6 @@ export interface CodeBundleDocument extends Document {
 export interface ContractDocument extends Document {
   abi: AnyJson;
   address: string;
-  blockZeroHash?: string;
   codeHash: string;
   creator: string;
   date: string;
@@ -62,10 +60,6 @@ export type CodeBundle = {
   document: CodeBundleDocument | null;
   isOnChain: boolean;
 };
-export interface CodeBundleQuery {
-  codeHash: string;
-  blockZeroHash?: string | null;
-}
 
 export interface Starred<T> {
   isExistent: boolean;

--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -38,7 +38,7 @@ export type ApiAction =
   | { type: 'KEYRING_ERROR' };
 
 export interface ChainProperties {
-  blockZeroHash: string | null;
+  blockOneHash: string | null;
   tokenDecimals: number;
   systemName: string | null;
   systemVersion: string | null;

--- a/src/ui/contexts/ApiContext.tsx
+++ b/src/ui/contexts/ApiContext.tsx
@@ -8,31 +8,62 @@ import { keyring } from '@polkadot/ui-keyring';
 import { INIT_STATE, DEFAULT_DECIMALS } from '../../constants';
 import type { ApiState, ChainProperties } from 'types';
 import { apiReducer } from 'ui/reducers';
+import { blockTimeMs } from 'api/util/blockTime';
 
 let loadedAccounts = false;
 
-async function getChainProperties(api: ApiPromise): Promise<ChainProperties> {
-  const [chainProperties, blockZeroHash, systemName, systemVersion] = await Promise.all([
-    api.rpc.system.properties(),
-    api.query.system.blockHash(0),
-    api.rpc.system.name(),
-    api.rpc.system.version(),
-  ]);
+async function getChainProperties(api: ApiPromise): Promise<ChainProperties | null> {
+  console.log('getChainProperties');
+  const blockNumber = (await api.rpc.chain.getHeader()).number.toNumber();
 
-  return {
-    blockZeroHash: blockZeroHash.toString(),
-    systemName: systemName.toString(),
-    systemVersion: systemVersion.toString(),
-    tokenDecimals: chainProperties.tokenDecimals.isSome
-      ? chainProperties.tokenDecimals.unwrap().toArray()[0].toNumber()
-      : DEFAULT_DECIMALS,
-    tokenSymbol: chainProperties.tokenSymbol.isSome
-      ? chainProperties.tokenSymbol
-          .unwrap()
-          .toArray()
-          .map(s => s.toString())[0]
-      : 'Unit',
-  };
+  if (blockNumber > 1) {
+    const [chainProperties, blockOneHash, systemName, systemVersion] = await Promise.all([
+      api.rpc.system.properties(),
+      api.query.system.blockHash(1),
+      api.rpc.system.name(),
+      api.rpc.system.version(),
+    ]);
+
+    const result = {
+      blockOneHash: blockOneHash.toString(),
+      systemName: systemName.toString(),
+      systemVersion: systemVersion.toString(),
+      tokenDecimals: chainProperties.tokenDecimals.isSome
+        ? chainProperties.tokenDecimals.unwrap().toArray()[0].toNumber()
+        : DEFAULT_DECIMALS,
+      tokenSymbol: chainProperties.tokenSymbol.isSome
+        ? chainProperties.tokenSymbol
+            .unwrap()
+            .toArray()
+            .map(s => s.toString())[0]
+        : 'Unit',
+    };
+
+    return result;
+  }
+
+  return null;
+}
+
+async function getChainPropertiesWhenReady(api: ApiPromise) {
+  let chainProperties = await getChainProperties(api);
+
+  if (!chainProperties) {
+    chainProperties = await new Promise(resolve => {
+      const interval = setInterval(() => {
+        getChainProperties(api)
+          .then(result => {
+            if (result) {
+              clearInterval(interval);
+              resolve(result);
+            }
+          })
+          .catch(console.error);
+      }, blockTimeMs(api).toNumber());
+    });
+  }
+
+  return chainProperties as ChainProperties;
 }
 
 export const ApiContext = React.createContext(INIT_STATE);
@@ -56,14 +87,14 @@ export const ApiContextProvider = ({ children }: React.PropsWithChildren<Partial
 
       dispatch({
         type: 'CONNECT_READY',
-        payload: await getChainProperties(_api),
+        payload: await getChainPropertiesWhenReady(_api),
       });
     });
 
     _api.on('ready', async () => {
       dispatch({
         type: 'CONNECT_READY',
-        payload: await getChainProperties(_api),
+        payload: await getChainPropertiesWhenReady(_api),
       });
     });
 

--- a/src/ui/contexts/DatabaseContext.tsx
+++ b/src/ui/contexts/DatabaseContext.tsx
@@ -12,7 +12,7 @@ import React, {
 import { useApi } from './ApiContext';
 import { init } from 'db/util';
 import type { DbState } from 'types';
-import { dropExpiredDocuments, findMyContracts, getUser } from 'db';
+import { findMyContracts, getUser } from 'db';
 
 export const DbContext: React.Context<DbState> = React.createContext({} as unknown as DbState);
 export const DbConsumer: React.Consumer<DbState> = DbContext.Consumer;
@@ -23,7 +23,7 @@ const INITIAL = { isDbReady: false } as unknown as DbState;
 export function DatabaseContextProvider({
   children,
 }: HTMLAttributes<HTMLDivElement>): JSX.Element | null {
-  const { status, blockZeroHash, endpoint } = useApi();
+  const { status, blockOneHash, endpoint } = useApi();
 
   const [state, setState] = useState<DbState>(INITIAL);
 
@@ -34,20 +34,17 @@ export function DatabaseContextProvider({
 
   useEffect((): void => {
     status === 'READY' &&
-      !!blockZeroHash &&
-      init(endpoint, isRemote)
-        .then(async ([db, user, identity]): Promise<void> => {
+      !!blockOneHash &&
+      init(endpoint, blockOneHash, isRemote)
+        .then(([db, user, identity]): void => {
           console.log('init once');
-          if (!isRemote) {
-            await dropExpiredDocuments(db, blockZeroHash);
-          }
 
           setState(state => ({ ...state, db, user, identity, isDbReady: true }));
         })
         .catch(e => {
           console.error(e);
         });
-  }, [blockZeroHash, endpoint, isRemote, status]);
+  }, [blockOneHash, endpoint, isRemote, status]);
 
   const refreshUserData = useCallback(async (): Promise<void> => {
     const user = await getUser(state.db, state.identity);

--- a/src/ui/hooks/useBlockTime.ts
+++ b/src/ui/hooks/useBlockTime.ts
@@ -7,17 +7,12 @@ import type { Time } from '@polkadot/util/types';
 
 import { useMemo } from 'react';
 
-import { BN, BN_ONE, BN_THOUSAND, BN_TWO, bnToBn, extractTime } from '@polkadot/util';
+import { BN, BN_ONE, bnToBn, extractTime } from '@polkadot/util';
 
 import { useApi } from 'ui/contexts/ApiContext';
+import { blockTimeMs } from 'api/util/blockTime';
 
 type Result = [number, string, Time];
-
-const DEFAULT_TIME = new BN(6_000);
-
-// Some chains incorrectly use these, i.e. it is se to values such as 0 or even 2
-// Use a low minimum validity threshold to check these against
-const THRESHOLD = BN_THOUSAND.div(BN_TWO);
 
 export const useBlockTime = (
   blocks: number | BN = BN_ONE,
@@ -27,18 +22,7 @@ export const useBlockTime = (
 
   return useMemo((): Result => {
     const a = apiOverride || api;
-    const blockTime = (a?.consts.babe?.expectedBlockTime || // Babe
-      // POW, eg. Kulupu
-      a?.consts.difficulty?.targetBlockTime ||
-      // Check against threshold to determine value validity
-      (a?.consts.timestamp?.minimumPeriod.gte(THRESHOLD)
-        ? // Default minimum period config
-          a.consts.timestamp.minimumPeriod.mul(BN_TWO)
-        : a?.query.parachainSystem
-        ? // default guess for a parachain
-          DEFAULT_TIME.mul(BN_TWO)
-        : // default guess for others
-          DEFAULT_TIME)) as BN;
+    const blockTime = blockTimeMs(a);
     const value = blockTime.mul(bnToBn(blocks)).toNumber();
     const time = extractTime(Math.abs(value));
     const { days, hours, minutes, seconds } = time;

--- a/src/ui/hooks/useCodeBundle.ts
+++ b/src/ui/hooks/useCodeBundle.ts
@@ -15,17 +15,17 @@ function isValidHash(input: OrFalsy<string>): boolean {
 }
 
 export function useCodeBundle(codeHash: string): DbQuery<CodeBundle> {
-  const { api, blockZeroHash } = useApi();
+  const { api } = useApi();
   const { db } = useDatabase();
 
   const query = useCallback(async (): Promise<CodeBundle> => {
     if (isValidHash(codeHash)) {
       const isOnChain = !(await api.query.contracts.codeStorage(codeHash)).isEmpty;
-      const document = await findCodeBundleByHash(db, { blockZeroHash, codeHash });
+      const document = await findCodeBundleByHash(db, codeHash);
       return { document, isOnChain };
     }
     return { document: null, isOnChain: false };
-  }, [api.query.contracts, blockZeroHash, codeHash, db]);
+  }, [api.query.contracts, codeHash, db]);
 
   return useDbQuery(query, result => !!result);
 }

--- a/src/ui/hooks/useWeight.ts
+++ b/src/ui/hooks/useWeight.ts
@@ -13,6 +13,7 @@ import type { UseWeight } from 'types';
 export const useWeight = (): UseWeight => {
   const { api } = useApi();
   const [blockTime] = useBlockTime();
+  console.log(blockTime);
   const [megaGas, _setMegaGas] = useState<BN>(
     (api?.consts.system.blockWeights
       ? api.consts.system.blockWeights.maxBlock


### PR DESCRIPTION
- Refactor database name to combine RPC url and block one hash
- On startup, wait for block 1 to pass to ensure correct db name is used
- Clear unused local dbs once the block hash no longer matches
- Removes blockOneHash/blockZeroHash from document schemas - now unnecessary

closes https://github.com/paritytech/substrate-contracts-explorer/issues/126